### PR TITLE
hop-node: Seperate out sync and poller phases 

### DIFF
--- a/packages/hop-node/src/db/TransfersDb.ts
+++ b/packages/hop-node/src/db/TransfersDb.ts
@@ -92,13 +92,6 @@ class TransfersDb extends BaseDb {
         }
       }
 
-      // An item must be explicitly marked settled or unsettled
-      // An undefined WithdrawalBondSettled means that the workers
-      // are still syncing
-      if (item.withdrawalBondSettled === undefined) {
-        return false
-      }
-
       return (
         item.transferRootHash &&
         item.withdrawalBonded &&

--- a/packages/hop-node/src/watchers/BondTransferRootWatcher.ts
+++ b/packages/hop-node/src/watchers/BondTransferRootWatcher.ts
@@ -40,9 +40,7 @@ class BondTransferRootWatcher extends BaseWatcherWithEventHandlers {
     })
   }
 
-  async syncUp (): Promise<any> {
-    this.logger.debug('syncing up events')
-
+  async syncHandler (): Promise<any> {
     const promises: Promise<any>[] = []
     if (this.isL1) {
       const l1Bridge = this.bridge as L1Bridge
@@ -67,10 +65,6 @@ class BondTransferRootWatcher extends BaseWatcherWithEventHandlers {
     }
 
     await Promise.all(promises)
-    this.logger.debug('done syncing')
-
-    await wait(this.resyncIntervalSec)
-    return this.syncUp()
   }
 
   async watch () {
@@ -95,19 +89,8 @@ class BondTransferRootWatcher extends BaseWatcherWithEventHandlers {
       })
   }
 
-  async pollCheck () {
-    while (true) {
-      if (!this.started) {
-        return
-      }
-      try {
-        await this.checkTransfersCommittedFromDb()
-      } catch (err) {
-        this.logger.error(`poll check error: ${err.message}`)
-        this.notifier.error(`poll check error: ${err.message}`)
-      }
-      await wait(this.pollIntervalSec)
-    }
+  async pollHandler () {
+    await this.checkTransfersCommittedFromDb()
   }
 
   async handleRawTransferRootBondedEvent (event: Event) {

--- a/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
@@ -64,9 +64,7 @@ class BondWithdrawalWatcher extends BaseWatcherWithEventHandlers {
     await super.start()
   }
 
-  async syncUp (): Promise<any> {
-    this.logger.debug('syncing up events')
-
+  async syncHandler (): Promise<any> {
     const promises: Promise<any>[] = []
     promises.push(
       this.bridge.mapWithdrawalBondedEvents(
@@ -91,10 +89,6 @@ class BondWithdrawalWatcher extends BaseWatcherWithEventHandlers {
     }
 
     await Promise.all(promises)
-    this.logger.debug('done syncing')
-
-    await wait(this.resyncIntervalSec)
-    return this.syncUp()
   }
 
   async watch () {
@@ -117,23 +111,11 @@ class BondWithdrawalWatcher extends BaseWatcherWithEventHandlers {
       })
   }
 
-  async pollCheck () {
+  async pollHandler () {
     if (this.isL1) {
       return
     }
-    while (true) {
-      if (!this.started) {
-        return
-      }
-      try {
-        await this.checkTransferSentFromDb()
-      } catch (err) {
-        console.error(err)
-        this.logger.error(`poll check error: ${err.message}`)
-        this.notifier.error(`poll check error: ${err.message}`)
-      }
-      await wait(this.pollIntervalSec)
-    }
+    await this.checkTransferSentFromDb()
   }
 
   async handleRawWithdrawalBondedEvent (event: Event) {

--- a/packages/hop-node/src/watchers/ChallengeWatcher.ts
+++ b/packages/hop-node/src/watchers/ChallengeWatcher.ts
@@ -31,9 +31,7 @@ class ChallengeWatcher extends BaseWatcherWithEventHandlers {
     this.contracts = config.contracts
   }
 
-  async syncUp (): Promise<any> {
-    this.logger.debug('syncing up events')
-
+  async syncHandler (): Promise<any> {
     const promises: Promise<any>[] = []
     promises.push(
       this.l1Bridge.mapTransferRootBondedEvents(
@@ -54,10 +52,6 @@ class ChallengeWatcher extends BaseWatcherWithEventHandlers {
     )
 
     await Promise.all(promises)
-    this.logger.debug('done syncing')
-
-    await wait(this.resyncIntervalSec)
-    return this.syncUp()
   }
 
   async watch () {
@@ -74,20 +68,9 @@ class ChallengeWatcher extends BaseWatcherWithEventHandlers {
       })
   }
 
-  async pollCheck () {
-    while (true) {
-      if (!this.started) {
-        return
-      }
-      try {
-        await this.checkTransferRootFromDb()
-        await this.checkChallengeFromDb()
-      } catch (err) {
-        this.logger.error(`poll check error: ${err.message}`)
-        this.notifier.error(`poll check error: ${err.message}`)
-      }
-      await wait(this.pollIntervalSec)
-    }
+  async pollHandler () {
+    await this.checkTransferRootFromDb()
+    await this.checkChallengeFromDb()
   }
 
   async handleRawTransferRootBondedEvent (event: Event) {

--- a/packages/hop-node/src/watchers/CommitTransferWatcher.ts
+++ b/packages/hop-node/src/watchers/CommitTransferWatcher.ts
@@ -56,12 +56,10 @@ class CommitTransfersWatcher extends BaseWatcherWithEventHandlers {
     await super.start()
   }
 
-  async syncUp (): Promise<any> {
+  async syncHandler (): Promise<any> {
     if (this.isL1) {
       return
     }
-
-    this.logger.debug('syncing up events')
 
     const promises: Promise<any>[] = []
     const l2Bridge = this.bridge as L2Bridge
@@ -84,10 +82,6 @@ class CommitTransfersWatcher extends BaseWatcherWithEventHandlers {
     )
 
     await Promise.all(promises)
-    this.logger.debug('done syncing')
-
-    await wait(this.resyncIntervalSec)
-    return this.syncUp()
   }
 
   async watch () {
@@ -108,23 +102,12 @@ class CommitTransfersWatcher extends BaseWatcherWithEventHandlers {
       })
   }
 
-  async pollCheck () {
+  async pollHandler () {
     if (this.isL1) {
       return
     }
 
-    while (true) {
-      if (!this.started) {
-        return
-      }
-      try {
-        await this.checkTransferSentFromDb()
-      } catch (err) {
-        this.logger.error(`poll check error: ${err.message}`)
-        this.notifier.error(`poll check error: ${err.message}`)
-      }
-      await wait(this.pollIntervalSec)
-    }
+    await this.checkTransferSentFromDb()
   }
 
   async handleRawTransfersCommittedEventForTransferIds (event: Event) {

--- a/packages/hop-node/src/watchers/StakeWatcher.ts
+++ b/packages/hop-node/src/watchers/StakeWatcher.ts
@@ -69,12 +69,6 @@ class StakeWatcher extends BaseWatcherWithEventHandlers {
     }
   }
 
-  async stop () {
-    this.bridge.removeAllListeners()
-    this.started = false
-    this.logger.setEnabled(false)
-  }
-
   async printAmounts () {
     let [credit, rawDebit, debit, balance, allowance] = await Promise.all([
       this.bridge.getCredit(),

--- a/packages/hop-node/src/watchers/classes/IBaseWatcher.ts
+++ b/packages/hop-node/src/watchers/classes/IBaseWatcher.ts
@@ -1,7 +1,15 @@
 export interface IBaseWatcher {
-  syncUp(): Promise<void>
-  watch(): Promise<void>
+  pollSync(): Promise<void>
+  preSyncHandler(): Promise<void>
+  syncHandler(): Promise<void>
+  postSyncHandler(): Promise<void>
+
   pollCheck(): Promise<void>
+  prePollHandler(): Promise<void>
+  pollHandler(): Promise<void>
+  postPollHandler(): Promise<void>
+
+  watch(): Promise<void>
   start(): Promise<void>
   stop(): Promise<void>
 }

--- a/packages/hop-node/src/watchers/xDomainMessageRelayWatcher.ts
+++ b/packages/hop-node/src/watchers/xDomainMessageRelayWatcher.ts
@@ -68,23 +68,11 @@ class xDomainMessageRelayWatcher extends BaseWatcherWithEventHandlers {
     return
   }
 
-  async pollCheck () {
-    while (true) {
-      if (!this.started) {
-        return
-      }
-      try {
-        await this.checkTransfersCommittedFromDb()
-      } catch (err) {
-        this.logger.error(`poll check error: ${err.message}`)
-        this.notifier.error(`poll check error: ${err.message}`)
-      }
-      await wait(this.pollIntervalSec)
-    }
+  async pollHandler () {
+    await this.checkTransfersCommittedFromDb()
   }
 
-  async syncUp (): Promise<any> {
-    this.logger.debug('syncing up events')
+  async syncHandler (): Promise<any> {
     if (this.isL1) {
       return
     }
@@ -110,10 +98,6 @@ class xDomainMessageRelayWatcher extends BaseWatcherWithEventHandlers {
     )
 
     await Promise.all(promises)
-    this.logger.debug('done syncing')
-
-    await wait(this.resyncIntervalSec)
-    return this.syncUp()
   }
 
   async handleRawTransferRootConfirmedEvent (event: Event) {


### PR DESCRIPTION
Separates out sync and poller into phases;

1. preSync
2. sync
3. postSync

and

1. prePoll
2. poll
3. postPoll

- Simplifies/dries up things (only deal with syncHandler/pollHandler)
- Removes while loops
- Removes polling logic from child classes 
- Adds isAllSiblingWatchersInitialSyncCompleted() that returns true when all sibling watchers have finished the initial sync

Checks unsettled transfers only after all settle watchers have completed initial sync