### PR TITLE
hop-node: refactor bondWithdrawalWatcher RPC calls

### DIFF
--- a/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
@@ -225,6 +225,18 @@ class BondWithdrawalWatcher extends BaseWatcherWithEventHandlers {
       return
     }
 
+    if (dbTransfer.transferRootId) {
+      const l1Bridge = this.getSiblingWatcherByChainSlug(Chain.Ethereum)
+        .bridge as L1Bridge
+      const transferRootConfirmed = await l1Bridge.isTransferRootIdConfirmed(
+        dbTransfer.transferRootId
+      )
+      if (transferRootConfirmed) {
+        logger.warn('transfer root already confirmed. Cannot bond withdrawal')
+        return
+      }
+    }
+
     await this.waitTimeout(transferId, destinationChainId)
 
     const { from: sender, data } = await sourceL2Bridge.getTransaction(

--- a/packages/hop-node/src/watchers/classes/ContractBase.ts
+++ b/packages/hop-node/src/watchers/classes/ContractBase.ts
@@ -154,7 +154,7 @@ export default class ContractBase extends EventEmitter {
       return
     }
 
-    // This number is granular enough to barely difference when using Hop
+    // This number is granular enough to hardly notice a difference when using Hop
     // TODO: wait the min time per chain and then try every 5s (124 * 4 for polygon, for example)
     const waitConfirmationSec = 20
     // keep waiting until latest block number is equal to or larger than

--- a/packages/hop-node/src/watchers/classes/ContractBase.ts
+++ b/packages/hop-node/src/watchers/classes/ContractBase.ts
@@ -154,11 +154,14 @@ export default class ContractBase extends EventEmitter {
       return
     }
 
+    // This number is granular enough to barely difference when using Hop
+    // TODO: wait the min time per chain and then try every 5s (124 * 4 for polygon, for example)
+    const waitConfirmationSec = 20
     // keep waiting until latest block number is equal to or larger than
     // target block number
     while (blockNumber < targetBlockNumber) {
       blockNumber = await this.contract.provider.getBlockNumber()
-      await wait(2 * 1000)
+      await wait(waitConfirmationSec * 1000)
     }
   }
 


### PR DESCRIPTION
This PR removes some RPC calls that appear to be unnecessary.

The biggest issue is that we would loop through each item marked `TransferSent` and make 5 RPC calls per chain on initial sync, in parallel, even if withdrawals were already bonded. This happened even if the transfer was bonded but the initial sync simply wasn't up-to-date.

- Do not allow txs to be sent during initial sync in order to guarantee DB state
  - We had a ton of calls being made during initial sync (5 RPC calls per any transfer ever sent in our system, in parallel + an event handler per tx)
- Removes an isBonder on chain call b/c we can assume only a bonder is running this software (1 RPC call per bond withdrawal)
- Remove `const isWithdrawalBonded = bondedAmount.gt(0) || isTransferIdSpent because` DB state is guaranteed (2 RPC calls per bond withdrawal + potential 1,000 block event sync)
- Do not validate that the transferRoot has been bonded on-chain because DB state is guaranteed (1 RPC call per bond withdrawal)
- Only check that the bonder has enough credit and not that the have >0 credit (1 RPC call per bond withdrawal)
- Increase wait confirmation checker from 2s to 20s. The total wait time is 144s, 210s, 248s on mainnet/xdai/poly, respectively. In the absolute worst case, a user will wait an extra 19.9s (saves 60-110 calls per bond withdrawal)