### PR TITLE
Bug/iterate through events batch

### DIFF
--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -607,7 +607,7 @@ export default class Bridge extends ContractBase {
       i++
     }
 
-    if (cacheKey) {
+    if (cacheKey && start === latestBlockInBatch) {
       await db.syncState.update(cacheKey, {
         latestBlockSynced: latestBlockInBatch,
         timestamp: Date.now()

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -623,21 +623,20 @@ export default class Bridge extends ContractBase {
 
     if (startBlockNumber && endBlockNumber) {
       end = endBlockNumber
-      start = startBlockNumber
-      totalBlocksInBatch = end - start
+      totalBlocksInBatch = end - startBlockNumber
     } else if (state?.latestBlockSynced) {
       end = currentBlockNumber
-      start = state.latestBlockSynced
-      totalBlocksInBatch = end - start
+      totalBlocksInBatch = end - state.latestBlockSynced
     } else {
       end = currentBlockNumber
-      start = end - batchBlocks
       totalBlocksInBatch = totalBlocks
       // Handle the case where the chain has less blocks than the total block config
       if (end - totalBlocksInBatch < 0) {
         totalBlocksInBatch = end
       }
     }
+
+    start = end - batchBlocks
 
     // NOTE: We do not handle the case where end minus batchBlocks is
     // a negative, which should never happen


### PR DESCRIPTION
3 fixes:

1. correctly iterate through `eventsBatch`
2. handle the case of a single iteration for `eventsBatch`
3. handle the case where an iteration looks before the intended `startBlock`