### PR TITLE
hop-node: remove unused code

### DIFF
--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -403,12 +403,7 @@ class SyncWatcher extends BaseWatcher {
           continue
         }
 
-        const eventRootHash = event.args.rootHash
         const eventDestinationChainId = Number(event.args.destinationChainId.toString())
-        const eventDbTransferRoot = await this.db.transferRoots.getByTransferRootHash(
-          eventRootHash
-        )
-
         const isSameChainId = eventDestinationChainId === destinationChainId
         if (endEvent && isSameChainId) {
           startEvent = event
@@ -428,13 +423,6 @@ class SyncWatcher extends BaseWatcher {
     const endBlockNumber = endEvent.blockNumber
     if (startEvent) {
       startBlockNumber = startEvent.blockNumber
-    }
-
-    if (!startBlockNumber) {
-      logger.error(
-        `Too many blocks between two TransfersCommitted events. Search Start: ${startSearchBlockNumber}. End Event: ${endEvent.blockNumber}`
-      )
-      return
     }
 
     logger.debug(`Searching for transfers between ${startBlockNumber} and ${endBlockNumber}`)

--- a/packages/hop-node/src/watchers/classes/BaseWatcher.ts
+++ b/packages/hop-node/src/watchers/classes/BaseWatcher.ts
@@ -120,7 +120,6 @@ class BaseWatcher extends EventEmitter implements IBaseWatcher {
   }
 
   async start () {
-    await this.bridge.waitTilReady()
     this.started = true
     try {
       await this.pollCheck()

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -62,6 +62,10 @@ export default class Bridge extends ContractBase {
       this.tokenSymbol = tokenSymbol
     }
     this.db = db.getDbSet(this.tokenSymbol)
+    const bridgeDeployedBlockNumber = config.tokens[this.tokenSymbol]?.[this.chainSlug]?.bridgeDeployedBlockNumber
+    if (!bridgeDeployedBlockNumber) {
+      throw new Error('bridge deployed block number is required')
+    }
     this.bridgeDeployedBlockNumber = config.tokens[this.tokenSymbol]?.[this.chainSlug]?.bridgeDeployedBlockNumber
   }
 

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -553,7 +553,6 @@ export default class Bridge extends ContractBase {
     cb: (start?: number, end?: number, i?: number) => Promise<void | boolean>,
     options: Partial<EventsBatchOptions> = {}
   ) {
-    await this.waitTilReady()
     this.validateEventsBatchInput(options)
 
     let cacheKey = ''

--- a/packages/hop-node/src/watchers/classes/ContractBase.ts
+++ b/packages/hop-node/src/watchers/classes/ContractBase.ts
@@ -10,7 +10,6 @@ export default class ContractBase extends EventEmitter {
   contract: Contract
   public chainId: number
   public chainSlug: string
-  public ready: boolean = true
 
   constructor (contract: Contract) {
     super()
@@ -24,15 +23,6 @@ export default class ContractBase extends EventEmitter {
     }
     this.chainSlug = chainSlug
     this.chainId = chainSlugToId(chainSlug)
-  }
-
-  async waitTilReady (): Promise<boolean> {
-    if (this.ready) {
-      return true
-    }
-
-    await wait(100)
-    return this.waitTilReady()
   }
 
   @rateLimitRetry

--- a/packages/hop-node/src/watchers/classes/ContractBase.ts
+++ b/packages/hop-node/src/watchers/classes/ContractBase.ts
@@ -3,7 +3,7 @@ import { BigNumber, Contract, providers } from 'ethers'
 import { Chain } from 'src/constants'
 import { EventEmitter } from 'events'
 import { Transaction } from 'src/types'
-import { chainIdToSlug, chainSlugToId, getProviderChainSlug, wait } from 'src/utils'
+import { chainIdToSlug, chainSlugToId, getProviderChainSlug } from 'src/utils'
 import { config } from 'src/config'
 
 export default class ContractBase extends EventEmitter {


### PR DESCRIPTION
@miguelmota This PR removes newly unused code because of recent code/sync optimizations. Code removal includes "too many blocks" error.

Three top level questions that relate to these and prior updates:
1. `ready` in the ContractBase class is set to `true` [upon initialization](https://github.com/hop-protocol/hop/blob/26c98128973985ab3caf3a572b51582e85d470fc/packages/hop-node/src/watchers/classes/ContractBase.ts#L13). If I understand that correctly, this class will be set to `ready` even before the completion of the constructor code. Does it make sense to initialize it to `false` and set it to `true` on the last line of the constructor?
2. Because constructors are synchronous, is it guaranteed the last line of the most base class (in this case, ContractBase), is truly the last thing to happen upon initialization?
3. If `this.bridgeDeployedBlockNumber` is `undefined` [here](https://github.com/hop-protocol/hop/blob/26c98128973985ab3caf3a572b51582e85d470fc/packages/hop-node/src/watchers/classes/Bridge.ts#L65), the process continues as if there is nothing wrong. This might happen if `bridgeDeployedBlockNumber` is not correctly set in the addresses package or the local address.json that the process is pointing to. Even though it runs with no errors, there are places in the code where we assume this is set. Does it make sense to perform an `if (!this.bridgeDeployedBlockNumber)` check after this is set? My only hesitation would be that there are many state vars that _could_ be checked as well.