### PR TITLE
Feature/exit watcher updates

### DIFF
--- a/packages/hop-node/src/watchers/ArbitrumBridgeWatcher.ts
+++ b/packages/hop-node/src/watchers/ArbitrumBridgeWatcher.ts
@@ -3,11 +3,13 @@ import chalk from 'chalk'
 import wallets from 'src/wallets'
 import { Bridge, OutgoingMessageState } from 'arb-ts'
 import { Chain } from 'src/constants'
-import { Wallet } from 'ethers'
+import { Contract, Wallet } from 'ethers'
 
 type Config = {
   chainSlug: string
   tokenSymbol: string
+  bridgeContract?: Contract
+  isL1?: boolean
   dryMode?: boolean
 }
 
@@ -23,6 +25,8 @@ class ArbitrumBridgeWatcher extends BaseWatcher {
       tokenSymbol: config.tokenSymbol,
       tag: 'ArbitrumBridgeWatcher',
       logColor: 'yellow',
+      bridgeContract: config.bridgeContract,
+      isL1: config.isL1,
       dryMode: config.dryMode
     })
 

--- a/packages/hop-node/src/watchers/OptimismBridgeWatcher.ts
+++ b/packages/hop-node/src/watchers/OptimismBridgeWatcher.ts
@@ -11,6 +11,8 @@ import { getRpcProvider, getRpcUrls } from 'src/utils'
 type Config = {
   chainSlug: string
   tokenSymbol: string
+  bridgeContract?: Contract
+  isL1?: boolean
   dryMode?: boolean
 }
 
@@ -29,6 +31,8 @@ class OptimismBridgeWatcher extends BaseWatcher {
       tokenSymbol: config.tokenSymbol,
       tag: 'OptimismBridgeWatcher',
       logColor: 'yellow',
+      bridgeContract: config.bridgeContract,
+      isL1: config.isL1,
       dryMode: config.dryMode
     })
 

--- a/packages/hop-node/src/watchers/PolygonBridgeWatcher.ts
+++ b/packages/hop-node/src/watchers/PolygonBridgeWatcher.ts
@@ -15,6 +15,8 @@ import { config as globalConfig } from 'src/config'
 type Config = {
   chainSlug: string
   tokenSymbol: string
+  bridgeContract?: Contract
+  isL1?: boolean
   dryMode?: boolean
 }
 
@@ -33,6 +35,8 @@ class PolygonBridgeWatcher extends BaseWatcher {
       tokenSymbol: config.tokenSymbol,
       tag: 'PolygonBridgeWatcher',
       logColor: 'yellow',
+      bridgeContract: config.bridgeContract,
+      isL1: config.isL1,
       dryMode: config.dryMode
     })
 

--- a/packages/hop-node/src/watchers/xDaiBridgeWatcher.ts
+++ b/packages/hop-node/src/watchers/xDaiBridgeWatcher.ts
@@ -13,6 +13,8 @@ type Config = {
   chainSlug: string
   tokenSymbol: string
   l1BridgeContract?: Contract
+  bridgeContract?: Contract
+  isL1?: boolean
   dryMode?: boolean
 }
 
@@ -63,7 +65,7 @@ export const executeExitTx = async (event: any, token: string) => {
   }
   const packedSigs = packSignatures(sigs)
 
-  const tx = l1Amb.executeSignatures(message, packedSigs)
+  const tx = await l1Amb.executeSignatures(message, packedSigs)
   return {
     tx,
     msgHash,
@@ -83,6 +85,8 @@ class xDaiBridgeWatcher extends BaseWatcher {
       tokenSymbol: config.tokenSymbol,
       tag: 'xDaiBridgeWatcher',
       logColor: 'yellow',
+      bridgeContract: config.bridgeContract,
+      isL1: config.isL1,
       dryMode: config.dryMode
     })
     if (config.l1BridgeContract) {
@@ -210,7 +214,6 @@ class xDaiBridgeWatcher extends BaseWatcher {
         this.notifier.info(
             `chainId: ${this.bridge.chainId} confirmTransferRoot L1 exit tx: ${tx.hash}`
         )
-        await tx.wait()
       }
     }
   }

--- a/packages/hop-node/src/watchers/xDomainMessageRelayWatcher.ts
+++ b/packages/hop-node/src/watchers/xDomainMessageRelayWatcher.ts
@@ -42,7 +42,7 @@ class xDomainMessageRelayWatcher extends BaseWatcher {
     })
     this.l1Bridge = new L1Bridge(config.l1BridgeContract)
     this.watchers[Chain.xDai] = new xDaiBridgeWatcher({
-      chainSlug: Chain.Polygon,
+      chainSlug: Chain.xDai,
       tokenSymbol: this.tokenSymbol,
       l1BridgeContract: config.l1BridgeContract,
       dryMode: config.dryMode

--- a/packages/hop-node/src/watchers/xDomainMessageRelayWatcher.ts
+++ b/packages/hop-node/src/watchers/xDomainMessageRelayWatcher.ts
@@ -42,26 +42,34 @@ class xDomainMessageRelayWatcher extends BaseWatcher {
     })
     this.l1Bridge = new L1Bridge(config.l1BridgeContract)
     this.watchers[Chain.xDai] = new xDaiBridgeWatcher({
-      chainSlug: Chain.xDai,
+      chainSlug: config.chainSlug,
       tokenSymbol: this.tokenSymbol,
       l1BridgeContract: config.l1BridgeContract,
+      bridgeContract: config.bridgeContract,
+      isL1: config.isL1,
       dryMode: config.dryMode
     })
     this.watchers[Chain.Polygon] = new PolygonBridgeWatcher({
-      chainSlug: Chain.Polygon,
+      chainSlug: config.chainSlug,
       tokenSymbol: this.tokenSymbol,
+      bridgeContract: config.bridgeContract,
+      isL1: config.isL1,
       dryMode: config.dryMode
     })
     this.watchers[Chain.Optimism] = new OptimismBridgeWatcher({
-      chainSlug: Chain.Optimism,
+      chainSlug: config.chainSlug,
       tokenSymbol: this.tokenSymbol,
+      bridgeContract: config.bridgeContract,
+      isL1: config.isL1,
       dryMode: config.dryMode
     })
-    // this.watchers[Chain.Arbitrum] = new ArbitrumBridgeWatcher({
-    //   chainSlug: Chain.Arbitrum,
-    //   tokenSymbol: this.tokenSymbol,
-    //   dryMode: config.dryMode
-    // })
+    this.watchers[Chain.Arbitrum] = new ArbitrumBridgeWatcher({
+      chainSlug: config.chainSlug,
+      tokenSymbol: this.tokenSymbol,
+      bridgeContract: config.bridgeContract,
+      isL1: config.isL1,
+      dryMode: config.dryMode
+    })
 
     // xDomain relayer is less time sensitive than others
     this.pollIntervalMs = 10 * 60 * 1000


### PR DESCRIPTION
Some quick exit watcher updates:

* Pass in `bridgeContract` to each chain's exit watcher so that the bridge is instantiated. This is needed because [this call](https://github.com/hop-protocol/hop/blob/c3acb4a63ba5133ba9c66d7595bcc63ad8bbef21/packages/hop-node/src/watchers/xDaiBridgeWatcher.ts#L145) was failing because `this.bridge` was undefined.
* `await` `executeSignatures` in [the xDai watcher](https://github.com/hop-protocol/hop/compare/feature/exit-watcher-updates?expand=1#diff-569334638dd3a8ef26b6ba9f24b423ee34b68c1f8bd625bd006b833b3345762fR68) so that `tx` can be returned and awaited 
* Use `this.chainSlug` to initialize the correct watcher instead of the chain's constant slug [here](https://github.com/hop-protocol/hop/compare/feature/exit-watcher-updates?expand=1#diff-3a295f79419414a98de893328e2c6fe8240aae1477af65f8d09f46dfba4866daR45).
* Move the timestamp check [here](https://github.com/hop-protocol/hop/compare/feature/exit-watcher-updates?expand=1#diff-3a295f79419414a98de893328e2c6fe8240aae1477af65f8d09f46dfba4866daR97) to the db getter. It was blocking manual exits where it used to be placed.
* (Low priority) Pass in `isL1` in order to give `BaseWatcher` a full initialization

To solve:
* (Low priority) Technically the Arbitrum exit watcher errors out upon node startup. I don't think this causes any issues and is probably just because Arbitrum is not supported everywhere yet. See startup logs for more information.