### PR TITLE
Feature/balances stats

### DIFF
--- a/packages/frontend/src/pages/Stats/BalanceStats.tsx
+++ b/packages/frontend/src/pages/Stats/BalanceStats.tsx
@@ -43,7 +43,7 @@ const BalanceStats: FC = () => {
     <Box display="flex" flexDirection="column" alignItems="center">
       <Box display="flex" alignItems="center">
         <Typography variant="h4" className={styles.title}>
-          Balances
+          Native Token Balances
         </Typography>
       </Box>
       <Box display="flex" alignItems="center" className={styles.box}>
@@ -52,6 +52,8 @@ const BalanceStats: FC = () => {
             <Table className={styles.table}>
               <TableHead>
                 <TableRow>
+                  <th>Network</th>
+                  <th>Name</th>
                   <th>Address</th>
                   <th>Balance</th>
                 </TableRow>
@@ -63,7 +65,7 @@ const BalanceStats: FC = () => {
                     .map((x, i) => {
                       return (
                           <TableRow key={i}>
-                            <TableCell colSpan={9}>
+                            <TableCell colSpan={4}>
                               <Skeleton animation="wave" width={'100%'} />
                             </TableCell>
                           </TableRow>
@@ -73,18 +75,10 @@ const BalanceStats: FC = () => {
                     return (
                         <TableRow key={item.id}>
                           <TableCell className={styles.cell}>
-                            <div className={styles.flex}>
-                              <img
-                                style={{
-                                  display: 'inline-block',
-                                  marginRight: '0.5em'
-                                }}
-                                src={item.network.imageUrl}
-                                alt=""
-                                width="16"
-                              />
-                              <span>{item.network.slug}.{item.token.symbol}</span>
-                            </div>
+                            {item.network}
+                          </TableCell>
+                          <TableCell className={styles.cell}>
+                            {item.name}
                           </TableCell>
                           <TableCell className={styles.cell}>
                             {item.address}

--- a/packages/frontend/src/pages/Stats/BalanceStats.tsx
+++ b/packages/frontend/src/pages/Stats/BalanceStats.tsx
@@ -1,0 +1,107 @@
+import React, { FC } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import Typography from '@material-ui/core/Typography'
+import Skeleton from '@material-ui/lab/Skeleton'
+import Paper from '@material-ui/core/Paper'
+import Box from '@material-ui/core/Box'
+import Table from '@material-ui/core/Table'
+import TableBody from '@material-ui/core/TableBody'
+import TableCell from '@material-ui/core/TableCell'
+import TableContainer from '@material-ui/core/TableContainer'
+import TableHead from '@material-ui/core/TableHead'
+import TableRow from '@material-ui/core/TableRow'
+import { useStats } from 'src/pages/Stats/StatsContext'
+import { commafy } from 'src/utils'
+
+const useStyles = makeStyles(theme => ({
+  paper: {
+    padding: '2rem'
+  },
+  table: {
+    width: '800px'
+  },
+  cell: {
+    fontSize: '1.4rem'
+  },
+  flex: {
+    display: 'flex'
+  },
+  title: {
+    marginBottom: '4.2rem'
+  },
+  box: {
+    marginBottom: '2rem',
+    flexDirection: 'column'
+  }
+}))
+
+const BalanceStats: FC = () => {
+  const styles = useStyles()
+  const { balances, fetchingBalances } = useStats()
+
+  return (
+    <Box display="flex" flexDirection="column" alignItems="center">
+      <Box display="flex" alignItems="center">
+        <Typography variant="h4" className={styles.title}>
+          Balances
+        </Typography>
+      </Box>
+      <Box display="flex" alignItems="center" className={styles.box}>
+        <Paper className={styles.paper}>
+          <TableContainer>
+            <Table className={styles.table}>
+              <TableHead>
+                <TableRow>
+                  <th>Address</th>
+                  <th>Balance</th>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {fetchingBalances
+                  ? Array(2)
+                    .fill(null)
+                    .map((x, i) => {
+                      return (
+                          <TableRow key={i}>
+                            <TableCell colSpan={9}>
+                              <Skeleton animation="wave" width={'100%'} />
+                            </TableCell>
+                          </TableRow>
+                      )
+                    })
+                  : balances?.map(item => {
+                    return (
+                        <TableRow key={item.id}>
+                          <TableCell className={styles.cell}>
+                            <div className={styles.flex}>
+                              <img
+                                style={{
+                                  display: 'inline-block',
+                                  marginRight: '0.5em'
+                                }}
+                                src={item.network.imageUrl}
+                                alt=""
+                                width="16"
+                              />
+                              <span>{item.network.slug}.{item.token.symbol}</span>
+                            </div>
+                          </TableCell>
+                          <TableCell className={styles.cell}>
+                            {item.address}
+                          </TableCell>
+                          <TableCell className={styles.cell}>
+                            {commafy(item.balance)}
+                          </TableCell>
+                        </TableRow>
+                    )
+                  })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
+      </Box>
+    </Box>
+  )
+}
+
+export default BalanceStats

--- a/packages/frontend/src/pages/Stats/DebitWindowStats.tsx
+++ b/packages/frontend/src/pages/Stats/DebitWindowStats.tsx
@@ -1,0 +1,119 @@
+import React, { FC } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import Typography from '@material-ui/core/Typography'
+import Skeleton from '@material-ui/lab/Skeleton'
+import Paper from '@material-ui/core/Paper'
+import Box from '@material-ui/core/Box'
+import Table from '@material-ui/core/Table'
+import TableBody from '@material-ui/core/TableBody'
+import TableCell from '@material-ui/core/TableCell'
+import TableContainer from '@material-ui/core/TableContainer'
+import TableHead from '@material-ui/core/TableHead'
+import TableRow from '@material-ui/core/TableRow'
+import { useStats } from 'src/pages/Stats/StatsContext'
+import { commafy } from 'src/utils'
+
+const useStyles = makeStyles(theme => ({
+  paper: {
+    padding: '2rem'
+  },
+  table: {
+    width: '800px'
+  },
+  cell: {
+    fontSize: '1.4rem'
+  },
+  flex: {
+    display: 'flex'
+  },
+  title: {
+    marginBottom: '4.2rem'
+  },
+  box: {
+    marginBottom: '2rem',
+    flexDirection: 'column'
+  }
+}))
+
+const DebitWindowStats: FC = () => {
+  const styles = useStyles()
+  const { debitWindowStats, fetchingDebitWindowStats } = useStats()
+
+  return (
+    <Box display="flex" flexDirection="column" alignItems="center">
+      <Box display="flex" alignItems="center">
+        <Typography variant="h4" className={styles.title}>
+          Debit Window Stats
+        </Typography>
+      </Box>
+      <Box display="flex" alignItems="center" className={styles.box}>
+        <Paper className={styles.paper}>
+          <TableContainer>
+            <Table className={styles.table}>
+              <TableHead>
+                <TableRow>
+                  <th>Token</th>
+                  <th>Slot 0</th>
+                  <th>Slot 1</th>
+                  <th>Slot 2</th>
+                  <th>Slot 3</th>
+                  <th>Slot 4</th>
+                  <th>Slot 5</th>
+                  <th>Mins Remaining</th>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {fetchingDebitWindowStats
+                  ? Array(2)
+                    .fill(null)
+                    .map((x, i) => {
+                      return (
+                          <TableRow key={i}>
+                            <TableCell colSpan={8}>
+                              <Skeleton animation="wave" width={'100%'} />
+                            </TableCell>
+                          </TableRow>
+                      )
+                    })
+                  : debitWindowStats?.map(item => {
+                    return (
+                        <TableRow key={item.id}>
+                          <TableCell className={styles.cell}>
+                            <div className={styles.flex}>
+                              <span>{item.token.symbol}</span>
+                            </div>
+                          </TableCell>
+                          <TableCell className={styles.cell}>
+                            {commafy(item.amountBonded[0])}
+                          </TableCell>
+                          <TableCell className={styles.cell}>
+                            {commafy(item.amountBonded[1])}
+                          </TableCell>
+                          <TableCell className={styles.cell}>
+                            {commafy(item.amountBonded[2])}
+                          </TableCell>
+                          <TableCell className={styles.cell}>
+                            {commafy(item.amountBonded[3])}
+                          </TableCell>
+                          <TableCell className={styles.cell}>
+                            {commafy(item.amountBonded[4])}
+                          </TableCell>
+                          <TableCell className={styles.cell}>
+                            {commafy(item.amountBonded[5])}
+                          </TableCell>
+                          <TableCell className={styles.cell}>
+                            {commafy(item.remainingMin)}
+                          </TableCell>
+                        </TableRow>
+                    )
+                  })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
+      </Box>
+    </Box>
+  )
+}
+
+export default DebitWindowStats

--- a/packages/frontend/src/pages/Stats/Stats.tsx
+++ b/packages/frontend/src/pages/Stats/Stats.tsx
@@ -5,6 +5,7 @@ import Box from '@material-ui/core/Box'
 import PoolStats from './PoolStats'
 import BonderStats from './BonderStats'
 import PendingAmountStats from './PendingAmountStats'
+import BalanceStats from './BalanceStats'
 
 const useStyles = makeStyles(theme => ({
   stats: {
@@ -25,6 +26,9 @@ const Stats: FC = () => {
       </div>
       <div className={styles.stats}>
         <BonderStats />
+      </div>
+      <div className={styles.stats}>
+        <BalanceStats />
       </div>
     </Box>
   )

--- a/packages/frontend/src/pages/Stats/Stats.tsx
+++ b/packages/frontend/src/pages/Stats/Stats.tsx
@@ -29,6 +29,9 @@ const Stats: FC = () => {
         <BonderStats />
       </div>
       <div className={styles.stats}>
+        <BalanceStats />
+      </div>
+      <div className={styles.stats}>
         <DebitWindowStats />
       </div>
     </Box>

--- a/packages/frontend/src/pages/Stats/Stats.tsx
+++ b/packages/frontend/src/pages/Stats/Stats.tsx
@@ -6,6 +6,7 @@ import PoolStats from './PoolStats'
 import BonderStats from './BonderStats'
 import PendingAmountStats from './PendingAmountStats'
 import BalanceStats from './BalanceStats'
+import DebitWindowStats from './DebitWindowStats'
 
 const useStyles = makeStyles(theme => ({
   stats: {
@@ -28,7 +29,7 @@ const Stats: FC = () => {
         <BonderStats />
       </div>
       <div className={styles.stats}>
-        <BalanceStats />
+        <DebitWindowStats />
       </div>
     </Box>
   )

--- a/packages/frontend/src/pages/Stats/StatsContext.tsx
+++ b/packages/frontend/src/pages/Stats/StatsContext.tsx
@@ -343,18 +343,17 @@ const StatsContextProvider: FC = ({ children }) => {
     }
 
     const bridge = sdk.bridge(selectedToken.symbol)
-    const slug: string = 'ethereum'
 
     const currentTime: number = Math.floor(Date.now() / 1000)
-    const currentTimeSlot: BigNumber = await bridge.getTimeSlot(slug, currentTime)
-    const challengePeriod: BigNumber = await bridge.challengePeriod(slug)
-    const timeSlotSize: BigNumber = await bridge.timeSlotSize(slug)
+    const currentTimeSlot: BigNumber = await bridge.getTimeSlot(currentTime)
+    const challengePeriod: BigNumber = await bridge.challengePeriod()
+    const timeSlotSize: BigNumber = await bridge.timeSlotSize()
     const numTimeSlots: BigNumber = challengePeriod.div(timeSlotSize)
     const amountBonded: number[] = []
 
     for (let i = 0; i < Number(numTimeSlots); i++) {
       const timeSlot: number = Number(currentTimeSlot.sub(i))
-      const amount: BigNumber = await bridge.timeSlotToAmountBonded(slug, timeSlot, bonder)
+      const amount: BigNumber = await bridge.timeSlotToAmountBonded(timeSlot, bonder)
       amountBonded.push(Number(formatUnits(amount.toString(), token.decimals)))
     }
 

--- a/packages/sdk/src/HopBridge.ts
+++ b/packages/sdk/src/HopBridge.ts
@@ -11,7 +11,7 @@ import {
   l2AmmWrapperAbi,
   wethAbi
 } from '@hop-protocol/core/abi'
-import { TChain, TToken, TAmount, TProvider } from './types'
+import { TChain, TToken, TAmount, TProvider, TTime, TTimeSlot } from './types'
 import Base, { ChainProviders } from './Base'
 import AMM from './AMM'
 import _version from './version'
@@ -1142,16 +1142,12 @@ class HopBridge extends Base {
   /**
    * @readonly
    * @desc The time slot for the current time.
-   * @param {Object} chain - Chain model.
-   * @param {Number} time - Unix timestamp (in seconds) to get the time slot.
+   * @param {Object} time - Unix timestamp (in seconds) to get the time slot.
    * @returns {Object} Time slot for the given time as BigNumber.
    */
-  public async getTimeSlot(
-    chain: TChain,
-    time: number
-  ): Promise<BigNumber> {
-    chain = this.toChainModel(chain)
-    const bridge = await this.getBridgeContract(chain)
+  public async getTimeSlot(time: TTime): Promise<BigNumber> {
+    const bridge = await this.getL1Bridge()
+    time = BigNumber.from(time.toString())
 
     return bridge.getTimeSlot(time)
   }
@@ -1159,12 +1155,10 @@ class HopBridge extends Base {
   /**
    * @readonly
    * @desc The challenge period.
-   * @param {Object} chain - Chain model.
    * @returns {Object} The challenge period for the bridge as BigNumber.
    */
-  public async challengePeriod(chain: TChain): Promise<BigNumber> {
-    chain = this.toChainModel(chain)
-    const bridge = await this.getBridgeContract(chain)
+  public async challengePeriod(): Promise<BigNumber> {
+    const bridge = await this.getL1Bridge()
 
     return bridge.challengePeriod()
   }
@@ -1172,12 +1166,10 @@ class HopBridge extends Base {
   /**
    * @readonly
    * @desc The size of the time slots.
-   * @param {Object} chain - Chain model.
    * @returns {Object} The size of the time slots for the bridge as BigNumber.
    */
-  public async timeSlotSize(chain: TChain): Promise<BigNumber> {
-    chain = this.toChainModel(chain)
-    const bridge = await this.getBridgeContract(chain)
+  public async timeSlotSize(): Promise<BigNumber> {
+    const bridge = await this.getL1Bridge()
 
     return bridge.TIME_SLOT_SIZE()
   }
@@ -1191,12 +1183,11 @@ class HopBridge extends Base {
    * @returns {Object} Amount bonded for the bonder for the given time slot as BigNumber.
    */
   public async timeSlotToAmountBonded(
-    chain: TChain,
-    timeSlot: number,
-    bonder: string
+    timeSlot: TTimeSlot,
+    bonder: string = this.getBonderAddress(this.tokenSymbol)
   ): Promise<BigNumber> {
-    chain = this.toChainModel(chain)
-    const bridge = await this.getBridgeContract(chain)
+    const bridge = await this.getL1Bridge()
+    timeSlot = BigNumber.from(timeSlot.toString())
 
     return bridge.timeSlotToAmountBonded(timeSlot, bonder)
   }

--- a/packages/sdk/src/HopBridge.ts
+++ b/packages/sdk/src/HopBridge.ts
@@ -1192,7 +1192,7 @@ class HopBridge extends Base {
    */
   public async timeSlotToAmountBonded(
     chain: TChain,
-    timeSlot: BigNumberish,
+    timeSlot: number,
     bonder: string
   ): Promise<BigNumber> {
     chain = this.toChainModel(chain)

--- a/packages/sdk/src/HopBridge.ts
+++ b/packages/sdk/src/HopBridge.ts
@@ -1139,6 +1139,68 @@ class HopBridge extends Base {
     return (Date.now() / 1000 + this.defaultDeadlineMinutes * 60) | 0
   }
 
+  /**
+   * @readonly
+   * @desc The time slot for the current time.
+   * @param {Object} chain - Chain model.
+   * @param {Number} time - Unix timestamp (in seconds) to get the time slot.
+   * @returns {Object} Time slot for the given time as BigNumber.
+   */
+  public async getTimeSlot(
+    chain: TChain,
+    time: number
+  ): Promise<BigNumber> {
+    chain = this.toChainModel(chain)
+    const bridge = await this.getBridgeContract(chain)
+
+    return bridge.getTimeSlot(time)
+  }
+
+  /**
+   * @readonly
+   * @desc The challenge period.
+   * @param {Object} chain - Chain model.
+   * @returns {Object} The challenge period for the bridge as BigNumber.
+   */
+  public async challengePeriod(chain: TChain): Promise<BigNumber> {
+    chain = this.toChainModel(chain)
+    const bridge = await this.getBridgeContract(chain)
+
+    return bridge.challengePeriod()
+  }
+
+  /**
+   * @readonly
+   * @desc The size of the time slots.
+   * @param {Object} chain - Chain model.
+   * @returns {Object} The size of the time slots for the bridge as BigNumber.
+   */
+  public async timeSlotSize(chain: TChain): Promise<BigNumber> {
+    chain = this.toChainModel(chain)
+    const bridge = await this.getBridgeContract(chain)
+
+    return bridge.TIME_SLOT_SIZE()
+  }
+
+  /**
+   * @readonly
+   * @desc The amount bonded for a time slot for a bonder.
+   * @param {Object} chain - Chain model.
+   * @param {Number} timeSlot - Time slot to get.
+   * @param {String} bonder - Address of the bonder to check.
+   * @returns {Object} Amount bonded for the bonder for the given time slot as BigNumber.
+   */
+  public async timeSlotToAmountBonded(
+    chain: TChain,
+    timeSlot: BigNumberish,
+    bonder: string
+  ): Promise<BigNumber> {
+    chain = this.toChainModel(chain)
+    const bridge = await this.getBridgeContract(chain)
+
+    return bridge.timeSlotToAmountBonded(timeSlot, bonder)
+  }
+
   private async getTokenIndexes (path: string[], chain: TChain) {
     const amm = this.getAmm(chain)
     const saddleSwap = await amm.getSaddleSwap()

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -10,5 +10,11 @@ export type TToken = Token | string
 /** Amount-ish type alias */
 export type TAmount = BigNumberish
 
+/** Time-ish type alias */
+export type TTime = BigNumberish
+
+/** TimeSlot-ish type alias */
+export type TTimeSlot = BigNumberish
+
 /** Signer-ish type */
 export type TProvider = Signer | providers.Provider


### PR DESCRIPTION
@miguelmota Can I get a review please. It appears to work and the end result is something like this.

<img width="609" alt="Screen Shot 2021-09-17 at 5 27 51 AM" src="https://user-images.githubusercontent.com/9441295/133782481-c3a04ea2-4952-4bde-9994-c6dc797d2b45.png">

 I think there are a few optimizations/best practices that I can do better with. Specifically:

* How to not use an arbitrary token [here](https://github.com/hop-protocol/hop/compare/feature/balances-stats?expand=1#diff-80ab0f08ae45d91eb42b384c92869fa289b01be5e0924a2bfd2083bb6734c3afR290)
* I wouldn't expect this to reload unless I refresh the page. Should I remove [this](https://github.com/hop-protocol/hop/compare/feature/balances-stats?expand=1#diff-80ab0f08ae45d91eb42b384c92869fa289b01be5e0924a2bfd2083bb6734c3afR390)?
* All virtual amounts are on L1. Is there a better way to do that without hardcoding `ethereum [here](https://github.com/hop-protocol/hop/compare/feature/balances-stats?expand=1#diff-80ab0f08ae45d91eb42b384c92869fa289b01be5e0924a2bfd2083bb6734c3afR346)?
* The SDK in general. There are a few things.
  * It is unclear if passing `chain` into each of the calls is expected.
  * The types. Specifically when to use `number` vs `BigNumber` vs `BigNumberish`
  * All of the calls I added are to the L1_Bridge. Is this the appropriate place/file for these calls?