### PR TITLE
Feature/retry not enough credit quicker

### DIFF
--- a/packages/hop-node/src/constants/constants.ts
+++ b/packages/hop-node/src/constants/constants.ts
@@ -50,7 +50,8 @@ export const MaxInt32 = 2147483647
 
 export enum TxError {
   CallException = 'CALL_EXCEPTION',
-  BonderFeeTooLow = 'BONDER_FEE_TOO_LOW'
+  BonderFeeTooLow = 'BONDER_FEE_TOO_LOW',
+  NotEnoughLiquidity = 'NOT_ENOUGH_LIQUIDITY'
 }
 
 export const MaxGasPriceMultiplier = 1.25

--- a/packages/hop-node/src/constants/constants.ts
+++ b/packages/hop-node/src/constants/constants.ts
@@ -50,8 +50,7 @@ export const MaxInt32 = 2147483647
 
 export enum TxError {
   CallException = 'CALL_EXCEPTION',
-  BonderFeeTooLow = 'BONDER_FEE_TOO_LOW',
-  NotEnoughLiquidity = 'NOT_ENOUGH_LIQUIDITY'
+  BonderFeeTooLow = 'BONDER_FEE_TOO_LOW'
 }
 
 export const MaxGasPriceMultiplier = 1.25

--- a/packages/hop-node/src/db/TransfersDb.ts
+++ b/packages/hop-node/src/db/TransfersDb.ts
@@ -128,8 +128,7 @@ class TransfersDb extends BaseDb {
 
       let timestampOk = true
       if (item.bondWithdrawalAttemptedAt) {
-        const checkBackoff = [TxError.BonderFeeTooLow, TxError.NotEnoughLiquidity].includes(item.withdrawalBondTxError)
-        if (checkBackoff) {
+        if (TxError.BonderFeeTooLow === item.withdrawalBondTxError) {
           const delay = TxRetryDelayMs + ((1 << item.withdrawalBondBackoffIndex) * 60 * 1000)
           // TODO: use `sentTransferTimestamp` once it's added to db
 

--- a/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
@@ -76,7 +76,7 @@ class BondWithdrawalWatcher extends BaseWatcher {
       const destinationChain = this.chainIdToSlug(destinationChainId)
       const lastAvailableCredit = this.lastAvailableCredit?.[sourceChain]?.[destinationChain]
       if (
-        (withdrawalBondTxError && withdrawalBondTxError === TxError.NotEnoughLiquidity) &&
+        (withdrawalBondTxError === TxError.NotEnoughLiquidity) &&
         (lastAvailableCredit && lastAvailableCredit.lt(amount))
       ) {
         continue

--- a/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
@@ -76,8 +76,9 @@ class BondWithdrawalWatcher extends BaseWatcher {
       const destinationChain = this.chainIdToSlug(destinationChainId)
       const lastAvailableCredit = this.lastAvailableCredit?.[sourceChain]?.[destinationChain]
       if (
-        (withdrawalBondTxError === TxError.NotEnoughLiquidity) &&
-        (lastAvailableCredit && lastAvailableCredit.lt(amount))
+        lastAvailableCredit &&
+        lastAvailableCredit.lt(amount) &&
+        withdrawalBondTxError === TxError.NotEnoughLiquidity
       ) {
         continue
       }

--- a/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
@@ -67,11 +67,15 @@ class BondWithdrawalWatcher extends BaseWatcher {
         transferId,
         sourceChainId,
         destinationChainId,
-        amount
+        amount,
+        withdrawalBondTxError
       } = dbTransfer
 
       const lastAvailableCredit = this.lastAvailableCredit[sourceChainId][destinationChainId]
-      if (lastAvailableCredit && lastAvailableCredit.lt(amount)) {
+      if (
+        (withdrawalBondTxError && withdrawalBondTxError === TxError.NotEnoughLiquidity) &&
+        (lastAvailableCredit && lastAvailableCredit.lt(amount))
+      ) {
         continue
       }
 
@@ -149,6 +153,9 @@ class BondWithdrawalWatcher extends BaseWatcher {
           availableCredit
         )}, need ${this.bridge.formatUnits(amount)}`
       )
+      await this.db.transfers.update(transferId, {
+        withdrawalBondTxError: TxError.NotEnoughLiquidity
+      })
       return
     }
 


### PR DESCRIPTION
This PR allows the bonder to re-bond transfers that are unbonded because there was not enough bonder liquidity at the time of the first attempted bond. At this time, we are seeing that a user in this case exponentially backs-off. In this case, the bonder's liquidity is replenished in 2 hours, for example, but the exponential backoff forces this transfer to take another few hours after the replenishment.

In order to optimize the time it takes to bond a transfer, we now store, in memory, the last available credit that the bonder had available for a given source/dest chainId. We now do not process transfers that are sending more value than the bonder has available.