### PR TITLE
Bugfix for a "bug" that changes the WMATIC ticker to WWMATIC

### DIFF
--- a/packages/frontend/src/pages/Pools/TokenWrapper/TokenWrapper.tsx
+++ b/packages/frontend/src/pages/Pools/TokenWrapper/TokenWrapper.tsx
@@ -81,7 +81,7 @@ const TokenWrapper: FC = () => {
         titleIconUrl={canonicalToken?.image}
         title={'Amount'}
         balance={wrappedTokenBalance}
-        balanceLabel={`W${wrappedToken?.symbol}:`}
+        balanceLabel={`${wrappedToken?.symbol}:`}
         loadingBalance={loadingBalance}
         hideSymbol
         decimalPlaces={2}


### PR DESCRIPTION
If a user goes to the Pool section of the Hop Exchange page and opens the wrap/unwrap section (for MATIC on Polygon), it shows a WWMATIC ticker instead of WMATIC. This can confuse people.

It's a small fix in hop/packages/frontend/src/pages/Pools/TokenWrapper/TokenWrapper.tsx ([line 84](https://github.com/hop-protocol/hop/blob/3501350629bc09c831056d05e06dfcda3c9a0865/packages/frontend/src/pages/Pools/TokenWrapper/TokenWrapper.tsx#L84)):

```javascript
balanceLabel={`W${wrappedToken?.symbol}:`}
```

I only removed "W" from this line 😉 

