### PR TITLE
Feature/bug bash

### DIFF
--- a/packages/hop-node/src/cli/commitTransfers.ts
+++ b/packages/hop-node/src/cli/commitTransfers.ts
@@ -1,4 +1,4 @@
-import CommitTransferWatcher from 'src/watchers/CommitTransferWatcher'
+import CommitTransfersWatcher from 'src/watchers/CommitTransfersWatcher'
 import chainSlugToId from 'src/utils/chainSlugToId'
 import {
   FileConfig,
@@ -49,7 +49,7 @@ program
         dryMode
       })
 
-      const watcher = findWatcher(watchers, CommitTransferWatcher, sourceChain) as CommitTransferWatcher
+      const watcher = findWatcher(watchers, CommitTransfersWatcher, sourceChain) as CommitTransfersWatcher
       if (!watcher) {
         throw new Error('watcher not found')
       }

--- a/packages/hop-node/src/cli/pendingTransfers.ts
+++ b/packages/hop-node/src/cli/pendingTransfers.ts
@@ -1,4 +1,4 @@
-import CommitTransferWatcher from 'src/watchers/CommitTransferWatcher'
+import CommitTransfersWatcher from 'src/watchers/CommitTransfersWatcher'
 import L2Bridge from 'src/watchers/classes/L2Bridge'
 import chainSlugToId from 'src/utils/chainSlugToId'
 import {
@@ -46,7 +46,7 @@ program
         dryMode: true
       })
 
-      const watcher = findWatcher(watchers, CommitTransferWatcher, sourceChain) as CommitTransferWatcher
+      const watcher = findWatcher(watchers, CommitTransfersWatcher, sourceChain) as CommitTransfersWatcher
       if (!watcher) {
         throw new Error('watcher not found')
       }

--- a/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
@@ -234,6 +234,7 @@ class BondWithdrawalWatcher extends BaseWatcher {
           withdrawalBondTxError: TxError.BonderFeeTooLow,
           withdrawalBondBackoffIndex
         })
+        return
       }
       throw err
     }

--- a/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
@@ -102,7 +102,6 @@ class BondWithdrawalWatcher extends BaseWatcher {
     } = dbTransfer
     const logger = this.logger.create({ id: transferId })
     const sourceL2Bridge = this.bridge as L2Bridge
-    const destinationChain = this.chainIdToSlug(destinationChainId)
     const destBridge = this.getSiblingWatcherByChainId(destinationChainId)
       .bridge
 

--- a/packages/hop-node/src/watchers/CommitTransfersWatcher.ts
+++ b/packages/hop-node/src/watchers/CommitTransfersWatcher.ts
@@ -31,7 +31,7 @@ class CommitTransfersWatcher extends BaseWatcher {
     super({
       chainSlug: config.chainSlug,
       tokenSymbol: config.tokenSymbol,
-      tag: 'CommitTransferWatcher',
+      tag: 'CommitTransfersWatcher',
       prefix: config.label,
       logColor: 'yellow',
       order: config.order,

--- a/packages/hop-node/src/watchers/watchers.ts
+++ b/packages/hop-node/src/watchers/watchers.ts
@@ -2,7 +2,7 @@ import '../moduleAlias'
 import BondTransferRootWatcher from 'src/watchers/BondTransferRootWatcher'
 import BondWithdrawalWatcher from 'src/watchers/BondWithdrawalWatcher'
 import ChallengeWatcher from 'src/watchers/ChallengeWatcher'
-import CommitTransferWatcher from 'src/watchers/CommitTransferWatcher'
+import CommitTransfersWatcher from 'src/watchers/CommitTransfersWatcher'
 import GasPriceWatcher from 'src/watchers/GasPriceWatcher'
 import SettleBondedWithdrawalWatcher from 'src/watchers/SettleBondedWithdrawalWatcher'
 import StakeWatcher from 'src/watchers/StakeWatcher'
@@ -13,7 +13,7 @@ import xDomainMessageRelayWatcher from 'src/watchers/xDomainMessageRelayWatcher'
 import { Chain } from 'src/constants'
 import { config as globalConfig } from 'src/config'
 
-type Watcher = BondTransferRootWatcher | BondWithdrawalWatcher | ChallengeWatcher | CommitTransferWatcher | SettleBondedWithdrawalWatcher | StakeWatcher | SyncWatcher | xDomainMessageRelayWatcher
+type Watcher = BondTransferRootWatcher | BondWithdrawalWatcher | ChallengeWatcher | CommitTransfersWatcher | SettleBondedWithdrawalWatcher | StakeWatcher | SyncWatcher | xDomainMessageRelayWatcher
 
 enum Watchers {
   BondWithdrawal = 'bondWithdrawal',
@@ -125,7 +125,7 @@ export function getWatchers (config: GetWatchersConfig) {
     watchers.push(...getSiblingWatchers({ networks, tokens }, ({ isL1, label, network, token, bridgeContract, tokenContract }: any) => {
       const minThresholdAmounts = commitTransfersMinThresholdAmounts?.[token]?.[network]
 
-      return new CommitTransferWatcher({
+      return new CommitTransfersWatcher({
         chainSlug: network,
         tokenSymbol: token,
         order,


### PR DESCRIPTION
Some house keeping commits:

* Change `CommitTransferWatcher` to `CommitTransfersWatcher` where appropriate.
* Only log if the bonder fee is too low. Do not throw an error.
* Wait 7 days before attempting an ORU exit.
  * I believe this will fix some (most) of our exit watcher errors, as we were trying to process exits ~10 minutes after a commit. I think.