### PR TITLE
hop-node: Db: Add key stream filter to filter within range

### DIFF
--- a/packages/hop-node/src/cli/dbDump.ts
+++ b/packages/hop-node/src/cli/dbDump.ts
@@ -20,6 +20,8 @@ program
   .option('--config <string>', 'Config file to use.')
   .option('--chain <string>', 'Chain')
   .option('--nearest <string>', 'Nearest timestamp')
+  .option('--from-date <string>', 'From date timestamp')
+  .option('--to-date <string>', 'To date timestamp')
   .description('Dump leveldb database')
   .action(async (source: any) => {
     try {
@@ -39,11 +41,16 @@ program
       const db = getDbSet(tokenSymbol)
       const chain = source.chain
       const nearest = Number(source.nearest)
+      const fromDate = Number(source.fromDate)
+      const toDate = Number(source.toDate)
       let items : any[] = []
       if (dbName === 'transfer-roots') {
         items = await db.transferRoots.getTransferRoots()
       } else if (dbName === 'transfers') {
-        items = await db.transfers.getTransfers()
+        items = await db.transfers.getTransfers({
+          fromUnix: fromDate,
+          toUnix: toDate
+        })
       } else if (dbName === 'sync-state') {
         items = await db.syncState.getItems()
       } else if (dbName === 'gas-prices') {

--- a/packages/hop-node/src/constants/constants.ts
+++ b/packages/hop-node/src/constants/constants.ts
@@ -37,6 +37,7 @@ export const DefaultBatchBlocks = 10000
 
 export const TenSecondsMs = 10 * 1000
 export const TenMinutesMs = 10 * 60 * 1000
+export const OneHourSeconds = 60 * 60
 export const OneHourMs = 60 * 60 * 1000
 export const OneWeekMs = 7 * 24 * 60 * 60 * 1000
 export const TxRetryDelayMs = OneHourMs

--- a/packages/hop-node/src/db/BaseDb.ts
+++ b/packages/hop-node/src/db/BaseDb.ts
@@ -16,6 +16,13 @@ export type BaseItem = {
   _createdAt?: number
 }
 
+export type KeyFilter = {
+  gt?: string
+  gte?: string
+  lt?: string
+  lte?: string
+}
+
 @boundClass
 class BaseDb {
   public db: any
@@ -99,10 +106,10 @@ class BaseDb {
     return this.db.del(id)
   }
 
-  protected async getKeys (): Promise<string[]> {
+  protected async getKeys (filter?: KeyFilter): Promise<string[]> {
     return new Promise((resolve, reject) => {
       const keys : string[] = []
-      this.db.createKeyStream()
+      this.db.createKeyStream(filter)
         .on('data', (key: string) => {
           // ignore this key that used previously to track unique ids
           if (key === 'ids') {

--- a/packages/hop-node/src/db/BaseDb.ts
+++ b/packages/hop-node/src/db/BaseDb.ts
@@ -16,6 +16,7 @@ export type BaseItem = {
   _createdAt?: number
 }
 
+// this are options that leveldb createReadStream accepts
 export type KeyFilter = {
   gt?: string
   gte?: string
@@ -124,6 +125,7 @@ class BaseDb {
       const kv : any[] = []
       this.db.createReadStream(filter)
         .on('data', (key: any, value: any) => {
+          // the parameter types depend on what key/value enabled options were used
           if (typeof key === 'object') {
             value = key.value
             key = key.key

--- a/packages/hop-node/src/db/GasPricesDb.ts
+++ b/packages/hop-node/src/db/GasPricesDb.ts
@@ -1,8 +1,8 @@
-import BaseDb, { BaseItem } from './BaseDb'
+import BaseDb, { BaseItem, KeyFilter } from './BaseDb'
 import nearest from 'nearest-date'
 import wait from 'src/utils/wait'
 import { BigNumber } from 'ethers'
-import { OneHourMs, OneWeekMs } from 'src/constants'
+import { OneHourMs, OneHourSeconds, OneWeekMs } from 'src/constants'
 import { normalizeDbItem } from './utils'
 
 export const varianceSeconds = 10 * 60
@@ -40,8 +40,8 @@ class GasPricesDb extends BaseDb {
     return this.update(key, data)
   }
 
-  async getItems ():Promise<GasPrice[]> {
-    const keys = await this.getKeys()
+  async getItems (filter?: KeyFilter):Promise<GasPrice[]> {
+    const keys = await this.getKeys(filter)
     const items: GasPrice[] = (await Promise.all(
       keys.map((key: string) => {
         return this.getById(key)
@@ -51,7 +51,13 @@ class GasPricesDb extends BaseDb {
   }
 
   async getNearest (chain: string, targetTimestamp: number, staleCheck: boolean = true): Promise<GasPrice | null> {
-    const items : GasPrice[] = (await this.getItems()).filter((item: GasPrice) => item.chain === chain && item.timestamp)
+    const startTimestamp = targetTimestamp - OneHourSeconds
+    const endTimestamp = targetTimestamp + OneHourSeconds
+    const filter = {
+      gte: `${chain}:${startTimestamp}`,
+      lte: `${chain}:${endTimestamp}`
+    }
+    const items : GasPrice[] = (await this.getItems(filter)).filter((item: GasPrice) => item.chain === chain && item.timestamp)
 
     const dates = items.map((item: GasPrice) => item.timestamp)
     const index = nearest(dates, targetTimestamp)

--- a/packages/hop-node/src/db/GasPricesDb.ts
+++ b/packages/hop-node/src/db/GasPricesDb.ts
@@ -55,7 +55,7 @@ class GasPricesDb extends BaseDb {
     const endTimestamp = targetTimestamp + OneHourSeconds
     const filter = {
       gte: `${chain}:${startTimestamp}`,
-      lte: `${chain}:${endTimestamp}`
+      lte: `${chain}:${endTimestamp}~`
     }
     const items : GasPrice[] = (await this.getItems(filter)).filter((item: GasPrice) => item.chain === chain && item.timestamp)
 

--- a/packages/hop-node/src/db/TokenPricesDb.ts
+++ b/packages/hop-node/src/db/TokenPricesDb.ts
@@ -53,7 +53,7 @@ class TokenPricesDb extends BaseDb {
     const endTimestamp = targetTimestamp + OneHourSeconds
     const filter = {
       gte: `${token}:${startTimestamp}`,
-      lte: `${token}:${endTimestamp}`
+      lte: `${token}:${endTimestamp}~`
     }
     const items : TokenPrice[] = (await this.getItems(filter)).filter((item: TokenPrice) => item.token === token && item.timestamp)
 

--- a/packages/hop-node/src/db/TokenPricesDb.ts
+++ b/packages/hop-node/src/db/TokenPricesDb.ts
@@ -1,7 +1,7 @@
-import BaseDb, { BaseItem } from './BaseDb'
+import BaseDb, { BaseItem, KeyFilter } from './BaseDb'
 import nearest from 'nearest-date'
 import wait from 'src/utils/wait'
-import { OneHourMs, OneWeekMs } from 'src/constants'
+import { OneHourMs, OneHourSeconds, OneWeekMs } from 'src/constants'
 import { normalizeDbItem } from './utils'
 
 export const varianceSeconds = 10 * 60
@@ -38,8 +38,8 @@ class TokenPricesDb extends BaseDb {
     return this.update(key, data)
   }
 
-  async getItems ():Promise<TokenPrice[]> {
-    const keys = await this.getKeys()
+  async getItems (filter?: KeyFilter):Promise<TokenPrice[]> {
+    const keys = await this.getKeys(filter)
     const items: TokenPrice[] = (await Promise.all(
       keys.map((key: string) => {
         return this.getById(key)
@@ -49,7 +49,13 @@ class TokenPricesDb extends BaseDb {
   }
 
   async getNearest (token: string, targetTimestamp: number, staleCheck: boolean = true): Promise<TokenPrice | null> {
-    const items : TokenPrice[] = (await this.getItems()).filter((item: TokenPrice) => item.token === token && item.timestamp)
+    const startTimestamp = targetTimestamp - OneHourSeconds
+    const endTimestamp = targetTimestamp + OneHourSeconds
+    const filter = {
+      gte: `${token}:${startTimestamp}`,
+      lte: `${token}:${endTimestamp}`
+    }
+    const items : TokenPrice[] = (await this.getItems(filter)).filter((item: TokenPrice) => item.token === token && item.timestamp)
 
     const dates = items.map((item: TokenPrice) => item.timestamp)
     const index = nearest(dates, targetTimestamp)

--- a/packages/hop-node/src/db/TransfersDb.ts
+++ b/packages/hop-node/src/db/TransfersDb.ts
@@ -1,8 +1,14 @@
-import BaseDb from './BaseDb'
+import BaseDb, { KeyFilter } from './BaseDb'
 import chainIdToSlug from 'src/utils/chainIdToSlug'
+import wait from 'src/utils/wait'
 import { BigNumber } from 'ethers'
 import { OneWeekMs, TxError, TxRetryDelayMs } from 'src/constants'
 import { normalizeDbItem } from './utils'
+
+export type TransfersDateFilter = {
+  fromUnix?: number
+  toUnix?: number
+}
 
 export type Transfer = {
   transferRootId?: string
@@ -36,8 +42,59 @@ export type Transfer = {
 }
 
 class TransfersDb extends BaseDb {
-  async update (transferId: string, data: Partial<Transfer>) {
-    return super.update(transferId, data)
+  ready = false
+
+  constructor (prefix: string, _namespace?: string) {
+    super(prefix, _namespace)
+
+    // this only needs to be ran once on start up to backfill timestamped keys.
+    // this function can be removed once all bonders update.
+    this.trackTimestampKeys()
+      .then(() => {
+        this.ready = true
+        this.logger.debug('transfersDb ready')
+      })
+      .catch(this.logger.error)
+  }
+
+  private async tilReady (): Promise<boolean> {
+    if (this.ready) {
+      return true
+    }
+
+    await wait(100)
+    return this.tilReady()
+  }
+
+  async trackTimestampKeys () {
+    const transfers = await this.getTransfers()
+    for (const transfer of transfers) {
+      await this.trackTimestampKey(transfer)
+    }
+  }
+
+  async trackTimestampKey (transfer: Partial<Transfer>) {
+    const transferId = transfer.transferId
+    const key = this.getTimestampKey(transfer)
+    if (!key || !transferId) {
+      return
+    }
+    const exists = await this.getById(key)
+    if (!exists) {
+      await super.update(key, { transferId })
+    }
+  }
+
+  getTimestampKey (transfer: Partial<Transfer>) {
+    if (transfer?.transferSentTimestamp && transfer?.transferSentIndex !== undefined) {
+      const key = `transfer:${transfer?.transferSentTimestamp}:${transfer?.transferSentIndex}`
+      return key
+    }
+  }
+
+  async update (transferId: string, transfer: Partial<Transfer>) {
+    await this.trackTimestampKey(transfer)
+    return super.update(transferId, transfer)
   }
 
   async getByTransferId (transferId: string): Promise<Transfer> {
@@ -57,12 +114,27 @@ class TransfersDb extends BaseDb {
     return normalizeDbItem(item)
   }
 
-  async getTransferIds (): Promise<string[]> {
-    return this.getKeys()
+  async getTransferIds (dateFilter?: TransfersDateFilter): Promise<string[]> {
+    if (dateFilter) {
+      // return only transfer-id keys that are within specified range
+      const filter : KeyFilter = {}
+      if (dateFilter.fromUnix) {
+        filter.gte = `transfer:${dateFilter.fromUnix}`
+      }
+      if (dateFilter.toUnix) {
+        filter.lte = `transfer:${dateFilter.toUnix}~`
+      }
+      const kv = await this.getKeyValues(filter)
+      return kv.map(x => x.value.transferId).filter(x => x)
+    }
+
+    // return all transfer-id keys if no filter is used
+    const keys = await this.getKeys()
+    return keys.filter((key: string) => !key?.startsWith('transfer:')).filter(x => x)
   }
 
-  async getTransfers (): Promise<Transfer[]> {
-    const transferIds = await this.getTransferIds()
+  async getTransfers (dateFilter?: TransfersDateFilter): Promise<Transfer[]> {
+    const transferIds = await this.getTransferIds(dateFilter)
     const transfers = await Promise.all(
       transferIds.map(transferId => {
         return this.getByTransferId(transferId)
@@ -70,7 +142,7 @@ class TransfersDb extends BaseDb {
     )
 
     // https://stackoverflow.com/a/9175783/1439168
-    return transfers
+    const items = transfers
       .filter(x => x)
       .sort((a, b) => {
         if (a.transferSentBlockNumber > b.transferSentBlockNumber) return 1
@@ -79,12 +151,25 @@ class TransfersDb extends BaseDb {
         if (a.transferSentIndex < b.transferSentIndex) return -1
         return 0
       })
+
+    console.log('items:', transfers.length)
+    console.timeEnd('elapsed')
+
+    return items
+  }
+
+  async getTransfersFromWeek () {
+    await this.tilReady()
+    const fromUnix = Math.floor((Date.now() - OneWeekMs) / 1000)
+    return this.getTransfers({
+      fromUnix
+    })
   }
 
   async getUncommittedTransfers (
     filter: Partial<Transfer> = {}
   ): Promise<Transfer[]> {
-    const transfers: Transfer[] = await this.getTransfers()
+    const transfers: Transfer[] = await this.getTransfersFromWeek()
     return transfers.filter(item => {
       if (filter?.sourceChainId) {
         if (filter.sourceChainId !== item.sourceChainId) {
@@ -104,7 +189,7 @@ class TransfersDb extends BaseDb {
   async getUnbondedSentTransfers (
     filter: Partial<Transfer> = {}
   ): Promise<Transfer[]> {
-    const transfers: Transfer[] = await this.getTransfers()
+    const transfers: Transfer[] = await this.getTransfersFromWeek()
     return transfers.filter(item => {
       if (filter?.sourceChainId) {
         if (filter.sourceChainId !== item.sourceChainId) {
@@ -156,7 +241,7 @@ class TransfersDb extends BaseDb {
   async getBondedTransfersWithoutRoots (
     filter: Partial<Transfer> = {}
   ): Promise<Transfer[]> {
-    const transfers: Transfer[] = await this.getTransfers()
+    const transfers: Transfer[] = await this.getTransfersFromWeek()
     return transfers.filter(item => {
       if (filter?.sourceChainId) {
         if (filter.sourceChainId !== item.sourceChainId) {

--- a/packages/hop-node/src/db/db.ts
+++ b/packages/hop-node/src/db/db.ts
@@ -5,8 +5,7 @@ import TokenPricesDb from './TokenPricesDb'
 import TransferRootsDb from './TransferRootsDb'
 import TransfersDb from './TransfersDb'
 
-// db instances (initialized only once)
-
+// these are the db instances (initialized only once).
 // gas prices and token prices db are global (not token specific)
 let gasPricesDb: GasPricesDb | null = null
 let tokenPricesDb: TokenPricesDb | null = null

--- a/packages/hop-node/src/db/db.ts
+++ b/packages/hop-node/src/db/db.ts
@@ -5,8 +5,19 @@ import TokenPricesDb from './TokenPricesDb'
 import TransferRootsDb from './TransferRootsDb'
 import TransfersDb from './TransfersDb'
 
+// db instances (initialized only once)
+
+// gas prices and token prices db are global (not token specific)
 let gasPricesDb: GasPricesDb | null = null
 let tokenPricesDb: TokenPricesDb | null = null
+
+// dbSets are token specific instances
+const dbSets : {[db: string]: {[tokenSymbol: string]: any}} = {
+  gasBoostDb: {},
+  syncStateDb: {},
+  transfersDb: {},
+  transferRootsDb: {}
+}
 
 export const getGasPricesDb = () => {
   if (!gasPricesDb) {
@@ -27,36 +38,31 @@ export function getDbSet (tokenSymbol: string) {
     throw new Error('token symbol is required to namespace leveldbs')
   }
 
-  let gasBoostDb : GasBoostDb | null = null
-  let syncStateDb: SyncStateDb | null = null
-  let transfersDb: TransfersDb | null = null
-  let transferRootsDb: TransferRootsDb | null = null
-
   // lazy instantiate with getters
   return {
     get gasBoost () {
-      if (!gasBoostDb) {
-        gasBoostDb = new GasBoostDb('gasBoost')
+      if (!dbSets.gasBoostDb[tokenSymbol]) {
+        dbSets.gasBoostDb[tokenSymbol] = new GasBoostDb('gasBoost')
       }
-      return gasBoostDb
+      return dbSets.gasBoostDb[tokenSymbol]
     },
     get syncState () {
-      if (!syncStateDb) {
-        syncStateDb = new SyncStateDb('state', tokenSymbol)
+      if (!dbSets.syncStateDb[tokenSymbol]) {
+        dbSets.syncStateDb[tokenSymbol] = new SyncStateDb('state', tokenSymbol)
       }
-      return syncStateDb
+      return dbSets.syncStateDb[tokenSymbol]
     },
     get transfers () {
-      if (!transfersDb) {
-        transfersDb = new TransfersDb('transfers', tokenSymbol)
+      if (!dbSets.transfersDb[tokenSymbol]) {
+        dbSets.transfersDb[tokenSymbol] = new TransfersDb('transfers', tokenSymbol)
       }
-      return transfersDb
+      return dbSets.transfersDb[tokenSymbol]
     },
     get transferRoots () {
-      if (!transferRootsDb) {
-        transferRootsDb = new TransferRootsDb('transferRoots', tokenSymbol)
+      if (!dbSets.transferRootsDb[tokenSymbol]) {
+        dbSets.transferRootsDb[tokenSymbol] = new TransferRootsDb('transferRoots', tokenSymbol)
       }
-      return transferRootsDb
+      return dbSets.transferRootsDb[tokenSymbol]
     },
     get gasPrices () {
       return getGasPricesDb()


### PR DESCRIPTION
Adds leveldb createKeyStream filter [options]( https://www.npmjs.com/package/levelup#dbcreatereadstreamoptions) to narrow lookup. Drastically improves lookup speed by having leveldb narrow the scope instead of filtering a constantly increasing list of entries.

Filter options added to `GasPricesDb` + `TokenPricesDb` `getNearest` method and `TransfersDb` db getters.

gas prices lookup example (finding an entry closest to timestamp):

without key filter

```
items: 19947
elapsed: 2430.229ms
```

![DeepinScreenshot_select-area_20211002220816](https://user-images.githubusercontent.com/168240/135740836-d203daa0-14f7-4082-bc14-efb1fb100ceb.png)

with key filter

```
items: 237
elapsed: 24.927ms
```

![DeepinScreenshot_select-area_20211002220744](https://user-images.githubusercontent.com/168240/135740839-39e41322-18c6-42f3-abbd-fea9a500080a.png)

both examples return expected entry.

Transfers db lookup example (finding entries between two dates):

without key filter

```
items: 7
elapsed: 546.952ms
```

![DeepinScreenshot_select-area_20211004010248](https://user-images.githubusercontent.com/168240/135815641-c1a41e14-608f-429b-8d0e-4c2c2cd0e3e1.png)

with key filter

```
items: 7
elapsed: 14.137ms
```

![DeepinScreenshot_select-area_20211004010155](https://user-images.githubusercontent.com/168240/135815658-e51b27da-0bda-4115-a937-7ceb685514f0.png)

both example return the same expected set of entries.

This [medium article](https://kevinsimper.medium.com/how-to-get-range-of-keys-in-leveldb-and-how-gt-and-lt-works-29a8f1e11782) explains filters in more detail (and the reason for using tilda).

@shanefontaine 