### PR TITLE
Feature/rate limit info and framework

### DIFF
--- a/packages/hop-node/src/decorators/rateLimitRetry.ts
+++ b/packages/hop-node/src/decorators/rateLimitRetry.ts
@@ -47,7 +47,7 @@ export function rateLimitRetryFn (fn: any): any {
         if (retries >= rateLimitMaxRetries) {
           logger.error(`max retries (${rateLimitMaxRetries}) reached. Error: ${err.message}`)
           // this must be a regular console log to print original function name
-          console.log(fn, id)
+          console.log(fn, id, ...args)
           notifier.error(`max retries (${rateLimitMaxRetries}) reached. Error: ${err.message}`)
           throw err
         }
@@ -59,7 +59,7 @@ export function rateLimitRetryFn (fn: any): any {
           }". retrying again in ${delayMs / 1000} seconds.`
         )
         // this must be a regular console log to print original function name
-        console.log(fn, id)
+        console.log(fn, id, ...args)
         // exponential backoff wait
         await wait(delayMs)
       }

--- a/packages/hop-node/src/decorators/rateLimitRetry.ts
+++ b/packages/hop-node/src/decorators/rateLimitRetry.ts
@@ -45,7 +45,7 @@ export function rateLimitRetryFn (fn: any): any {
         retries++
         // if it's a rate limit error, then throw error after max retries attempted.
         if (retries >= rateLimitMaxRetries) {
-          logger.error(`max retries (${rateLimitMaxRetries}) reached. Error: ${err.message}`)
+          logger.error(`max retries (${rateLimitMaxRetries}) reached. Error: ${err}`)
           // this must be a regular console log to print original function name
           console.log(fn, id, ...args)
           notifier.error(`max retries (${rateLimitMaxRetries}) reached. Error: ${err.message}`)

--- a/packages/hop-node/src/watchers/StakeWatcher.ts
+++ b/packages/hop-node/src/watchers/StakeWatcher.ts
@@ -92,21 +92,7 @@ class StakeWatcher extends BaseWatcher {
     this.logger.debug('credit balance:', this.bridge.formatUnits(credit))
     this.logger.debug('raw debit balance:', this.bridge.formatUnits(rawDebit))
     this.logger.debug('debit balance:', this.bridge.formatUnits(debit))
-
-    const bondedBondedWithdrawalsBalance = await this.bridge.getBonderBondedWithdrawalsBalance()
-
-    const bonderBridgeStakedAmount = credit
-      .sub(rawDebit)
-      .add(bondedBondedWithdrawalsBalance)
-
-    this.logger.debug(
-      'bonder bonded withdrawals balance:',
-      this.bridge.formatUnits(bondedBondedWithdrawalsBalance)
-    )
-    this.logger.debug(
-      'bonder bridge calculated actual staked amount:',
-      this.bridge.formatUnits(bonderBridgeStakedAmount)
-    )
+    this.logger.debug('allowance:', this.bridge.formatUnits(allowance))
   }
 
   async watchEthBalance () {

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -162,27 +162,6 @@ export default class Bridge extends ContractBase {
     return totalBondedAmount
   }
 
-  @rateLimitRetry
-  async getBonderBondedWithdrawalsBalance (): Promise<BigNumber> {
-    const bonderAddress = await this.getBonderAddress()
-    let total = BigNumber.from(0)
-    await this.eventsBatch(async (start: number, end: number) => {
-      const withdrawalBondedEvents = await this.getWithdrawalBondedEvents(
-        start,
-        end
-      )
-      for (const event of withdrawalBondedEvents) {
-        const { transferId } = event.args
-        const amount = await this.getBondedWithdrawalAmountByBonder(
-          bonderAddress,
-          transferId
-        )
-        total = total.add(amount)
-      }
-    })
-    return total
-  }
-
   async getBondedWithdrawalTimestamp (
     transferId: string,
     startBlockNumber?: number,

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -107,7 +107,6 @@ export default class Bridge extends ContractBase {
     return debit
   }
 
-  @rateLimitRetry
   async getBaseAvailableCredit (bonder?: string): Promise<BigNumber> {
     const [credit, debit] = await Promise.all([
       this.getCredit(bonder),
@@ -116,7 +115,6 @@ export default class Bridge extends ContractBase {
     return credit.sub(debit)
   }
 
-  @rateLimitRetry
   async hasPositiveBalance (): Promise<boolean> {
     const credit = await this.getBaseAvailableCredit()
     return credit.gt(0)
@@ -239,7 +237,6 @@ export default class Bridge extends ContractBase {
     )
   }
 
-  @rateLimitRetry
   async getTransferRootSetTxHash (
     transferRootHash: string
   ): Promise<string | undefined> {
@@ -494,7 +491,6 @@ export default class Bridge extends ContractBase {
     return Number(res)
   }
 
-  @rateLimitRetry
   async getEthBalance (): Promise<BigNumber> {
     const bonder = await this.getBonderAddress()
     return this.getBalance(bonder)

--- a/packages/hop-node/src/watchers/classes/ContractBase.ts
+++ b/packages/hop-node/src/watchers/classes/ContractBase.ts
@@ -106,15 +106,11 @@ export default class ContractBase extends EventEmitter {
     return block.timestamp
   }
 
-  @rateLimitRetry
   async getTransactionTimestamp (
     txHash: string
   ): Promise<number> {
-    const tx = await this.contract.provider.getTransaction(txHash)
-    if (!tx) {
-      throw new Error(`expected tx object. transactionHash: ${txHash}`)
-    }
-    return this.getBlockTimestamp(tx.blockNumber)
+    const blockNumber = await this.getTransactionBlockNumber(txHash)
+    return this.getBlockTimestamp(blockNumber)
   }
 
   async getEventTimestamp (event: any): Promise<number> {
@@ -148,7 +144,6 @@ export default class ContractBase extends EventEmitter {
     return this.contract.provider.getGasPrice()
   }
 
-  @rateLimitRetry
   protected async getBumpedGasPrice (multiplier: number): Promise<BigNumber> {
     const gasPrice = await this.getGasPrice()
     return getBumpedGasPrice(gasPrice, multiplier)

--- a/packages/hop-node/src/watchers/classes/L2Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/L2Bridge.ts
@@ -141,7 +141,6 @@ export default class L2Bridge extends Bridge {
     return this.mapEventsBatch(this.getTransferSentEvents, cb, options)
   }
 
-  @rateLimitRetry
   async getTransferSentTimestamp (transferId: string): Promise<number> {
     let match: Event
     await this.eventsBatch(async (start: number, end: number) => {
@@ -299,7 +298,6 @@ export default class L2Bridge extends Bridge {
     )
   }
 
-  @rateLimitRetry
   async doPendingTransfersExist (chainId: number): Promise<boolean> {
     try {
       await this.getPendingTransferByIndex(chainId, 0)
@@ -340,7 +338,6 @@ export default class L2Bridge extends Bridge {
     )
   }
 
-  @rateLimitRetry
   async getPendingTransfers (chainId: number): Promise<string[]> {
     const pendingTransfers: string[] = []
     const max = await this.getMaxPendingTransfers()


### PR DESCRIPTION
_This PR resolves #181_

There are three pieces to this PR:
1. Fix an issue where we were experiencing `timedout` errors at seemingly random times
2. Add additional logs when a `timedout` error does occur
3. Define a framework for when to use the `@rateLimitRetry` decorator and implement it

---

### Item 1

We have been seeing an issue on the MATIC bonder recently (two `timedout` errors upon startup) and on the Stablecoin bonder (many `timedout` errors upon startup). The root issue is that we were using an `@rateLimitRetry` decorator on a function that then calls `eventsBatch()`. Now that we have sufficient state to iterate over, this call (and others like it) will error out because they take longer than what the top-level `@rateLimitRetry` decorator allows for (90s).

The fix is to remove the `@rateLimitRetry` decorator from that function. However, I believe this is legacy code and the returned data would not be very informative, so I removed the function completely.

I believe I understand that the intent is to log the expected stake. I now believe that we should not show this, as it will require iterating over the entire state upon ever startup. Instead, if we want to know that information, it is reasonable to look at the timestamp of these logs and then perform a manual lookup of the bonder's expected stake at that time. I'm not sure there is a better way to do this without iterating over every block up startup _or_ storing this info in a DB entry via the sync watcher—neither are good ideas, IMO.

LMK what you think here. Happy to hear another suggestion.

### Item 2

Self explanatory. Added `...args` to the logs of a failed `@rateLimitRetry` attempt.

### Item 3

I think we all agree on it, but, to put it into words, a framework for using the `@rateLimitRetry` decorator should be:
* If a function makes a direct on-chain call, use a `@rateLimitRetry` decorator
* If a function calls `eventsBatch`, do not use a `@rateLimitRetry` decorator
* If a function only make on-chain calls & those calls are already decorated with `@rateLimitRetry`, do not use a `@rateLimitRetry` decorator

The first point is self explanatory & we do this already. The second point is to avoid the issue mentioned in Item (1)—if an `eventsBatch()` takes more than 90s, then it will fail because we set a timelimit on how long it should take. It is my understanding that each individual `eventsBatch()` call is rate limited, so there should be no need to decorate the top level function with `@rateLimitRetry`. The third point is less critical but I think is good practice. If a function makes on-chain calls and those calls are made through an already-rate-limited function we defined, then I do not believe the top-level function should be decorated with `@rateLimitRetry`. An example is [here](https://github.com/hop-protocol/hop/compare/feature/rate-limit-info-and-framework?expand=1#diff-3d4e66dfcb7e60e93d03604ab5d18080d0e500368a6c4e340c52ee43ab1da805R493).

One advantage of this framework is that it will allow us to see exactly which call is failing and when because the `rateLimitRetryFn()` only log the information associated with the decorated function that failed. My only hesitation with this framework is that we do not ever log the top level function call that fails. This might be not ideal for some `eventsBatch()` failures or [the example I gave above](https://github.com/hop-protocol/hop/compare/feature/rate-limit-info-and-framework?expand=1#diff-3d4e66dfcb7e60e93d03604ab5d18080d0e500368a6c4e340c52ee43ab1da805R493) (in this example, if `getBalance()` failed, then the logs would show that `getBalance()` failed and I'm not sure it would mention that `getEthBalance()` was the top-level function that failed).

LMK what you think about all this. I am happy to walk back on some of these changes if you believe them to be invalid changes.

One final note -- I am not sure what to do about the `@rateLimitRetry` decorator on the [`gasBoost.sendTransaction()`](https://github.com/hop-protocol/hop/blob/develop/packages/hop-node/src/gasboost/GasBoostSigner.ts#L48) function. I do believe it is necessary, as we make an on-chain call. However, if that call gets retried a few times because of nonces, then the transaction will fail because of the 90s timer. Maybe the answer is to retry just the on-chain call and not this whole function. Up for discussion.