### PR TITLE
hop-node: update state check for already bonded transfers

### DIFF
--- a/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
@@ -109,8 +109,8 @@ class BondWithdrawalWatcher extends BaseWatcher {
 
     await this.waitTimeout(transferId, destinationChainId)
 
-    const bondedAmount = await destBridge.getTotalBondedWithdrawalAmountForTransferId(transferId)
-    if (bondedAmount.gt(0)) {
+    const isTransferSpent = await destBridge.isTransferIdSpent(transferId)
+    if (isTransferSpent) {
       logger.warn('transfer already bonded. Adding to db and skipping')
       const event = await destBridge.getBondedWithdrawalEvent(transferId)
       if (event) {
@@ -352,10 +352,8 @@ class BondWithdrawalWatcher extends BaseWatcher {
       if (!this.started) {
         return
       }
-      const bondedAmount = await bridge.getTotalBondedWithdrawalAmountForTransferId(
-        transferId
-      )
-      if (!bondedAmount.eq(0)) {
+      const isTransferSpent = await bridge.isTransferIdSpent(transferId)
+      if (isTransferSpent) {
         break
       }
       const delay = 2 * 1000

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -141,25 +141,6 @@ export default class Bridge extends ContractBase {
     return bondedBn
   }
 
-  async getTotalBondedWithdrawalAmountForTransferId (
-    transferId: string
-  ): Promise<BigNumber> {
-    let totalBondedAmount = BigNumber.from(0)
-    const bonderAddress = await this.getBonderAddress()
-    let bonders = [bonderAddress]
-    if (globalConfig?.bonders?.[this.tokenSymbol]) {
-      bonders = unique([bonderAddress, ...globalConfig.bonders[this.tokenSymbol]])
-    }
-    for (const bonder of bonders) {
-      const bondedAmount = await this.getBondedWithdrawalAmountByBonder(
-        bonder,
-        transferId
-      )
-      totalBondedAmount = totalBondedAmount.add(bondedAmount)
-    }
-    return totalBondedAmount
-  }
-
   async getBondedWithdrawalTimestamp (
     transferId: string,
     startBlockNumber?: number,


### PR DESCRIPTION
When bonding a transfer, we used to check how much of the transfer was bonded. If a value existed, we knew it was bonded. This has a flaw, however, because the amount would be `0` after that bond had been settled.

This PR uses `isTransferIdSpent()` to check if a transfer has been bonded. On-chain, this is marked as `true` for a transfer ID whenever that ID is bonded or withdrawn, which is what we are trying to checking for here.

I know it is super old code, but as an FYI I removed the entire `getTotalBondedWithdrawalAmountForTransferId()` function, as it will not always be correct. If a transfer is bonded by a bonder that does not exist in the config, then that will return `0` even though it is not true. Additionally, only one bonder can bond a transfer, so summing the amounts transferred for each shouldn't do anything. I think a more useful function would be to return the bonder that bonded the transfer root, but since (1) we wouldn't use that function anywhere at this time, (2) we have that data in the DB, and (3) it is still subject to the bonder-not-in-config issue I mentioend above, I decided not to add that function. LMK if you have any thoughts on all this.