### PR TITLE
hop-node: OsWatcher: Log disk size

### DIFF
--- a/packages/hop-node/package.json
+++ b/packages/hop-node/package.json
@@ -69,6 +69,7 @@
     "aws-sdk": "^2.937.0",
     "bip39": "3.0.4",
     "chalk": "4.1.0",
+    "check-disk-space": "^3.0.1",
     "commander": "6.2.0",
     "console-clear": "^1.1.1",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
Logs used/total disk size, using [`check-disk-space`](https://www.npmjs.com/package/check-disk-space) package (150,000 weekly downloads)

Example

![DeepinScreenshot_select-area_20211014104605](https://user-images.githubusercontent.com/168240/137369582-7c827156-487b-43a7-bfa2-b3c3b7bb0fc7.png)
