### PR TITLE
Prometheus metrics server scaffolding

### DIFF
--- a/packages/hop-node/package.json
+++ b/packages/hop-node/package.json
@@ -79,6 +79,7 @@
     "ethereumjs-util": "^7.0.9",
     "ethers": "5.4.5",
     "expect": "^26.6.2",
+    "express": "^4.17.1",
     "fast-memoize": "^2.5.2",
     "js-yaml": "^4.1.0",
     "keythereum": "1.2.0",
@@ -106,6 +107,8 @@
     "web3-utils": "^1.3.4"
   },
   "devDependencies": {
+    "@types/commander": "^2.12.2",
+    "@types/express": "^4.17.13",
     "@types/jest": "^26.0.20",
     "@types/level": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^4.28.2",

--- a/packages/hop-node/src/arb-bot/ArbBot.ts
+++ b/packages/hop-node/src/arb-bot/ArbBot.ts
@@ -78,8 +78,10 @@ class ArbBot {
 
       while (true) {
         try {
-          await this.checkArbitrage()
-          await this.checkBalances()
+          await Promise.all([
+            this.checkArbitrage(),
+            this.checkBalances()
+          ])
           this.logger.log(`Rechecking in ${this.pollIntervalSec} seconds`)
           await wait(this.pollIntervalSec * 1e3)
         } catch (err) {

--- a/packages/hop-node/src/cli/bonder.ts
+++ b/packages/hop-node/src/cli/bonder.ts
@@ -1,13 +1,14 @@
 import {
   FileConfig,
   defaultEnabledWatchers,
+  config as globalConfig,
   parseConfigFile,
-  setConfigByNetwork
-  , setGlobalConfigFromConfigFile
+  setConfigByNetwork,
+  setGlobalConfigFromConfigFile
 } from 'src/config'
+import { MetricsServer } from 'src/metrics'
 import { logger, parseArgList, program } from './shared'
 import { printHopArt } from './shared/art'
-
 import { startWatchers } from 'src/watchers/watchers'
 
 program
@@ -54,6 +55,9 @@ program
         tokens,
         networks
       })
+      if (globalConfig.metrics?.enabled) {
+        await new MetricsServer(logger, globalConfig.metrics?.port).start()
+      }
     } catch (err) {
       logger.error(err)
       process.exit(1)

--- a/packages/hop-node/src/cli/healthCheck.ts
+++ b/packages/hop-node/src/cli/healthCheck.ts
@@ -45,7 +45,7 @@ program
     const pollIntervalSeconds = Number(source.pollIntervalSeconds)
 
     try {
-      new HealthCheck({
+      await new HealthCheck({
         bondWithdrawalTimeLimitMinutes,
         bondTransferRootTimeLimitMinutes,
         commitTransfersMinThresholdAmount,

--- a/packages/hop-node/src/cli/hopNode.ts
+++ b/packages/hop-node/src/cli/hopNode.ts
@@ -177,15 +177,20 @@ program
           minThreshold
         })
       }
+      const promises: Array<Promise<void>> = []
       if (config?.roles?.xdaiBridge) {
         for (const token of tokens) {
-          new xDaiBridgeWatcher({
+          promises.push(new xDaiBridgeWatcher({
             chainSlug: Chain.xDai,
             tokenSymbol: token
-          }).start()
+          }).start())
         }
       }
-      new OsWatcher().start()
+      promises.push(new Promise((resolve) => {
+        new OsWatcher().start()
+        resolve()
+      }))
+      await Promise.all(promises)
     } catch (err) {
       logger.error(`hop-node error: ${err.message}\ntrace: ${err.stack}`)
       process.exit(1)

--- a/packages/hop-node/src/cli/loadTest.ts
+++ b/packages/hop-node/src/cli/loadTest.ts
@@ -35,8 +35,8 @@ program
             .map((v: string) => v.trim())
             .filter((v: string) => v)
         })
-        .filter((x: any) => x && x?.length)
-      new LoadTest({
+        .filter((x: any) => x?.length)
+      await new LoadTest({
         concurrentUsers: Number(source.concurrentUsers || 1),
         iterations: Number(source.iterations || 1),
         amount: Number(source.amount || 0),

--- a/packages/hop-node/src/cli/polygonBridge.ts
+++ b/packages/hop-node/src/cli/polygonBridge.ts
@@ -21,13 +21,15 @@ program
         const config: FileConfig = await parseConfigFile(configPath)
         await setGlobalConfigFromConfigFile(config)
       }
-      const tokens = Object.keys(globalConfig.tokens)
+      const tokens = Object.keys(globalConfig.tokens ?? {})
+      const promises: Array<Promise<void>> = []
       for (const token of tokens) {
-        new PolygonBridgeWatcher({
+        promises.push(new PolygonBridgeWatcher({
           chainSlug: Chain.Polygon,
           tokenSymbol: token
-        }).start()
+        }).start())
       }
+      await Promise.all(promises)
     } catch (err) {
       logger.error(err)
       process.exit(1)

--- a/packages/hop-node/src/cli/xdaiBridge.ts
+++ b/packages/hop-node/src/cli/xdaiBridge.ts
@@ -21,13 +21,15 @@ program
         const config: FileConfig = await parseConfigFile(configPath)
         await setGlobalConfigFromConfigFile(config)
       }
-      const tokens = Object.keys(globalConfig.tokens)
+      const tokens = Object.keys(globalConfig.tokens ?? {})
+      const promises: Array<Promise<void>> = []
       for (const token of tokens) {
-        new xDaiBridgeWatcher({
+        promises.push(new xDaiBridgeWatcher({
           chainSlug: Chain.xDai,
           tokenSymbol: token
-        }).start()
+        }).start())
       }
+      await Promise.all(promises)
     } catch (err) {
       logger.error(err)
       process.exit(1)

--- a/packages/hop-node/src/config/config.ts
+++ b/packages/hop-node/src/config/config.ts
@@ -56,17 +56,22 @@ type SyncConfigs = { [key: string]: SyncConfig }
 type DbConfig = {
   path: string
 }
-type Config = {
+interface MetricsConfig {
+  enabled: boolean
+  port?: number
+}
+interface Config {
   isMainnet: boolean
-  tokens:Bridges & {[network: string]: any},
-  network: string,
-  networks: Networks & {[network: string]: any},
-  bonderPrivateKey: string,
-  metadata: Metadata & {[network: string]: any},
-  bonders: Bonders,
-  stateUpdateAddress: string,
-  db: DbConfig,
-  sync: SyncConfigs,
+  tokens: Bridges & {[network: string]: any}
+  network: string
+  networks: Networks & {[network: string]: any}
+  bonderPrivateKey: string
+  metadata: Metadata & {[network: string]: any}
+  bonders: Bonders
+  stateUpdateAddress: string
+  db: DbConfig
+  sync: SyncConfigs
+  metrics: MetricsConfig
 }
 
 const networkConfigs: {[key: string]: any} = {
@@ -135,6 +140,9 @@ export const config: Config = {
       totalBlocks: TotalBlocks.xDai,
       batchBlocks: DefaultBatchBlocks
     }
+  },
+  metrics: {
+    enabled: true
   }
 }
 
@@ -209,6 +217,10 @@ export const getEnabledNetworks = (): string[] => {
     }
   }
   return Object.keys(networks)
+}
+
+export const setMetricsConfig = (metricsConfig: MetricsConfig) => {
+  config.metrics = { ...config.metrics, ...metricsConfig }
 }
 
 export const chainNativeTokens = ['ETH', 'MATIC', 'DAI']

--- a/packages/hop-node/src/config/fileOps.ts
+++ b/packages/hop-node/src/config/fileOps.ts
@@ -17,6 +17,7 @@ import {
 import { getParameter } from 'src/aws/parameterStore'
 import { promptPassphrase } from 'src/prompt'
 import { recoverKeystore } from 'src/keystore'
+import { setMetricsConfig } from '.'
 
 const logger = new Logger('config')
 
@@ -82,7 +83,12 @@ type LoggingConfig = {
   level: string
 }
 
-export type Addresses = {
+interface MetricsConfig {
+  enabled: boolean
+  port?: number
+}
+
+export interface Addresses {
   location: string
 }
 
@@ -102,6 +108,7 @@ export type FileConfig = {
   order?: number
   addresses?: Addresses
   stateUpdateAddress?: string
+  metrics?: MetricsConfig
 }
 
 export async function setGlobalConfigFromConfigFile (
@@ -163,6 +170,9 @@ export async function setGlobalConfigFromConfigFile (
   }
   if (config?.stateUpdateAddress) {
     setStateUpdateAddress(config.stateUpdateAddress)
+  }
+  if (config?.metrics) {
+    setMetricsConfig(config.metrics)
   }
 }
 

--- a/packages/hop-node/src/config/validation.ts
+++ b/packages/hop-node/src/config/validation.ts
@@ -1,5 +1,5 @@
 import { Chain } from 'src/constants'
-import { getEnabledNetworks, getEnabledTokens } from 'src/config'
+import { FileConfig, getEnabledNetworks, getEnabledTokens } from 'src/config'
 
 export function isValidToken (token: string) {
   const tokens = getEnabledTokens()
@@ -19,7 +19,7 @@ export function validateKeys (validKeys: string[] = [], keys: string[]) {
   }
 }
 
-export async function validateConfig (config: any) {
+export async function validateConfig (config?: FileConfig) {
   if (!config) {
     throw new Error('config is required')
   }
@@ -44,7 +44,8 @@ export async function validateConfig (config: any) {
     'keystore',
     'addresses',
     'order',
-    'stateUpdateAddress'
+    'stateUpdateAddress',
+    'metrics'
   ]
 
   const validWatcherKeys = [
@@ -115,6 +116,12 @@ export async function validateConfig (config: any) {
     const validCommitTransfersKeys = ['minThresholdAmount']
     const commitTransfersKeys = Object.keys(config.commitTransfers)
     await validateKeys(validCommitTransfersKeys, commitTransfersKeys)
+  }
+
+  if (config.metrics) {
+    const validMetricsKeys = ['enabled', 'port']
+    const metricsKeys = Object.keys(config.metrics)
+    await validateKeys(validMetricsKeys, metricsKeys)
   }
 
   if (config.addresses) {

--- a/packages/hop-node/src/metrics/MetricsServer.ts
+++ b/packages/hop-node/src/metrics/MetricsServer.ts
@@ -1,0 +1,34 @@
+import Logger from 'src/logger'
+import express, { Express } from 'express'
+import { Registry, collectDefaultMetrics } from 'prom-client'
+import { metrics } from './metrics'
+
+export class MetricsServer {
+  app: Express
+  registry: Registry
+  constructor (private readonly logger: Logger, private readonly port = 8080) {
+    this.registry = new Registry()
+    MetricsServer._registerCustomMetrics(this.registry)
+    this.app = express()
+    this.app.get('/metrics', async (req, resp) => {
+      resp.setHeader('Content-Type', this.registry.contentType)
+      resp.send(await this.registry.metrics())
+    })
+  }
+
+  async start () {
+    collectDefaultMetrics({
+      register: this.registry,
+      gcDurationBuckets: [0.001, 0.01, 0.1, 1, 2, 5]
+    })
+    this.app.listen(this.port, () => {
+      this.logger.info(`metrics server listening on port ${8080} at /metrics`)
+    })
+  }
+
+  private static _registerCustomMetrics (registry: Registry): void {
+    for (const metric of Object.values(metrics)) {
+      registry.registerMetric(metric)
+    }
+  }
+}

--- a/packages/hop-node/src/metrics/index.ts
+++ b/packages/hop-node/src/metrics/index.ts
@@ -1,0 +1,2 @@
+export * from './MetricsServer'
+export * from './metrics'

--- a/packages/hop-node/src/metrics/metrics.ts
+++ b/packages/hop-node/src/metrics/metrics.ts
@@ -1,0 +1,9 @@
+import { Gauge } from 'prom-client'
+
+export const metrics = {
+  bonderBalance: new Gauge({
+    name: 'bonder_balance',
+    help: 'Balance of the bonder for a particular token and chain',
+    labelNames: ['token', 'chain'] as const
+  })
+}


### PR DESCRIPTION
Sets up scaffolding for a metrics server and adds a metric for the bonder's various balances.

StakeWatcher is probably not the right place to update that metric since it seems it only ever loads up the bonder's balances once at startup. Should probably plumb all the watchers or all the bridge contracts directly into the metrics server and let it poll on its own.

Test by running the node as a bonder and then 

```bash
$ curl localhost:8080/metrics

# HELP bonder_balance Balance of the bonder for a particular token and chain
# TYPE bonder_balance gauge
bonder_balance{chain="ethereum",token="USDC"} 1000
bonder_balance{chain="ethereum",token="ETH"} 0.1
```