### PR TITLE
UI: prevent modal from closing when dragging slider outside

### DIFF
--- a/packages/frontend/src/components/modal/Modal.tsx
+++ b/packages/frontend/src/components/modal/Modal.tsx
@@ -139,7 +139,11 @@ const Modal = forwardRef<HTMLElement, Partial<ActivityDetailsProps>>(function Mo
               unmountOnExit={false}
             >
               <div className={classnames(styles.container, transitionState)}>
-                <ClickAwayListener onClickAway={handleClose}>
+                <ClickAwayListener
+                  onClickAway={handleClose}
+                  mouseEvent="onMouseDown"
+                  touchEvent="onTouchStart"
+                >
                   <Card className={styles.card} ref={ref}>
                     <div className={styles.close} onClick={handleClose}>
                       ✕


### PR DESCRIPTION
addresses #206 

this pr sets the `ClickAwayListener` component to respond to leading events (as opposed to trailing events)

more info: https://mui.com/components/click-away-listener/#leading-edge