### PR TITLE
Fix/async syncing

### DIFF
--- a/packages/hop-node/src/db/TransferRootsDb.ts
+++ b/packages/hop-node/src/db/TransferRootsDb.ts
@@ -365,6 +365,23 @@ class TransferRootsDb extends TimestampedKeysDb<TransferRoot> {
       )
     })
   }
+
+  async getItemsWithoutAllSettledState (
+    filter: Partial<TransferRoot> = {}
+  ) {
+    const transferRoots: TransferRoot[] = await this.getItems()
+    return transferRoots.filter(item => {
+      if (filter.sourceChainId) {
+        if (filter.sourceChainId !== item.sourceChainId) {
+          return false
+        }
+      }
+
+      return (
+        item?.allSettled === undefined
+      )
+    })
+  }
 }
 
 export default TransferRootsDb

--- a/packages/hop-node/src/watchers/SettleBondedWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/SettleBondedWithdrawalWatcher.ts
@@ -96,7 +96,7 @@ class SettleBondedWithdrawalWatcher extends BaseWatcher {
       const allBondableTransfersSettled = dbTransfers.every(
         (dbTransfer: Transfer) => {
           // A transfer should not be settled if it is unbondable
-          return !dbTransfer?.isBondable || dbTransfer.withdrawalBondSettled
+          return !dbTransfer.isBondable || dbTransfer.withdrawalBondSettled
         }
       )
       if (allBondableTransfersSettled) {

--- a/packages/hop-node/src/watchers/SettleBondedWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/SettleBondedWithdrawalWatcher.ts
@@ -96,7 +96,7 @@ class SettleBondedWithdrawalWatcher extends BaseWatcher {
       const allBondableTransfersSettled = dbTransfers.every(
         (dbTransfer: Transfer) => {
           // A transfer should not be settled if it is unbondable
-          return !dbTransfer.isBondable || dbTransfer.withdrawalBondSettled
+          return !dbTransfer?.isBondable || dbTransfer.withdrawalBondSettled
         }
       )
       if (allBondableTransfersSettled) {


### PR DESCRIPTION
Some event handlers had dependencies on other event handlers. This PR fixes that by removing all dependencies. This allows for:

1. Faster sync because it is fully async
2. Guaranteed DB state because `allSettled` is now written only after all DB items exist