### PR TITLE
hop-node/sdk: reduce L2 to L2 bonder fee

### DIFF
--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -689,10 +689,10 @@ export default class Bridge extends ContractBase {
       return BigNumber.from(0)
     }
 
-    // absolute minimum is $1 of token
+    const minBonderFeeUsd = 0.25
     const tokenDecimals = getTokenDecimals(tokenSymbol)
     const minBonderFeeAbsolute = parseUnits(
-      (1 / tokenPriceUsd).toFixed(tokenDecimals),
+      (minBonderFeeUsd / tokenPriceUsd).toFixed(tokenDecimals),
       tokenDecimals
     )
 

--- a/packages/sdk/src/HopBridge.ts
+++ b/packages/sdk/src/HopBridge.ts
@@ -814,8 +814,9 @@ class HopBridge extends Base {
     const token = this.toTokenModel(this.tokenSymbol)
     const tokenPrice = await this.priceFeed.getPriceByTokenSymbol(token.symbol)
 
+    const minBonderFeeUsd = 0.25
     const minBonderFeeAbsolute = parseUnits(
-      (1 / tokenPrice).toFixed(token.decimals),
+      (minBonderFeeUsd / tokenPrice).toFixed(token.decimals),
       token.decimals
     )
 


### PR DESCRIPTION
Simple PR to reduce the min bonder fee