### PR TITLE
hop-node: prep for regenesis

### DIFF
--- a/packages/core/build/addresses/mainnet.json
+++ b/packages/core/build/addresses/mainnet.json
@@ -66,7 +66,7 @@
         "l2AmmWrapper": "0x2ad09850b0CA4c7c1B33f5AcD6cBAbCaB5d6e796",
         "l2SaddleSwap": "0x3c0FFAca566fCcfD9Cc95139FEF6CBA143795963",
         "l2SaddleLpToken": "0x2e17b8193566345a2Dd467183526dEdc42d2d5A8",
-        "bridgeDeployedBlockNumber": 856160
+        "bridgeDeployedBlockNumber": 0
       },
       "arbitrum": {
         "l1CanonicalBridge": "0x0000000000000000000000000000000000000000",
@@ -127,7 +127,7 @@
         "l2AmmWrapper": "0x7D269D3E0d61A05a0bA976b7DBF8805bF844AF3F",
         "l2SaddleSwap": "0xeC4B41Af04cF917b54AEb6Df58c0f8D78895b5Ef",
         "l2SaddleLpToken": "0xF753A50fc755c6622BBCAa0f59F0522f264F006e",
-        "bridgeDeployedBlockNumber": 856444
+        "bridgeDeployedBlockNumber": 0
       },
       "arbitrum": {
         "l1CanonicalBridge": "0x0000000000000000000000000000000000000000",
@@ -225,7 +225,7 @@
         "l2AmmWrapper": "0xb3C68a491608952Cb1257FC9909a537a0173b63B",
         "l2SaddleSwap": "0xF181eD90D6CfaC84B8073FdEA6D34Aa744B41810",
         "l2SaddleLpToken": "0x22D63A26c730d49e5Eab461E4f5De1D8BdF89C92",
-        "bridgeDeployedBlockNumber": 1746403
+        "bridgeDeployedBlockNumber": 0
       },
       "arbitrum": {
         "l1CanonicalBridge": "0x0000000000000000000000000000000000000000",
@@ -286,7 +286,7 @@
         "l2AmmWrapper": "0x86cA30bEF97fB651b8d866D45503684b90cb3312",
         "l2SaddleSwap": "0xaa30D6bba6285d0585722e2440Ff89E23EF68864",
         "l2SaddleLpToken": "0x5C2048094bAaDe483D0b1DA85c3Da6200A88a849",
-        "bridgeDeployedBlockNumber": 3153382
+        "bridgeDeployedBlockNumber": 0
       },
       "arbitrum": {
         "l1CanonicalBridge": "0x0000000000000000000000000000000000000000",
@@ -347,7 +347,7 @@
         "l2AmmWrapper": "0x2A11a98e2fCF4674F30934B5166645fE6CA35F56",
         "l2SaddleSwap": "0x46fc3Af3A47792cA3ED06fdF3D657145A675a8D8",
         "l2SaddleLpToken": "0x07CE97eb3f375901D26Ec1e32144292318839802",
-        "bridgeDeployedBlockNumber": 3564522
+        "bridgeDeployedBlockNumber": 0
       },
       "arbitrum": {
         "l1CanonicalBridge": "0x0000000000000000000000000000000000000000",

--- a/packages/hop-node/src/config/fileOps.ts
+++ b/packages/hop-node/src/config/fileOps.ts
@@ -32,7 +32,7 @@ export const defaultEnabledWatchers: { [key: string]: boolean } = {
 }
 
 export const defaultEnabledNetworks: { [key: string]: boolean } = {
-  [Chain.Optimism]: true,
+  [Chain.Optimism]: false,
   [Chain.Arbitrum]: true,
   [Chain.xDai]: true,
   [Chain.Polygon]: true,

--- a/packages/hop-node/src/db/SyncStateDb.ts
+++ b/packages/hop-node/src/db/SyncStateDb.ts
@@ -14,13 +14,13 @@ class SyncStateDb extends BaseDb {
   constructor (prefix: string, _namespace?: string) {
     super(prefix, _namespace)
     this.migrations()
-      .then(() => {this.ready = true})
+      .then(() => { this.ready = true })
       .catch(this.logger.error)
   }
 
   async migrations () {
     const items = await this.getKeyValues()
-    for (let { key, value } of items) {
+    for (const { key, value } of items) {
       if (key?.startsWith(`${chainSlugToId(Chain.Optimism)}:`)) {
         await this._update(key, Object.assign({}, value, {
           latestBlockSynced: 0,
@@ -58,6 +58,7 @@ class SyncStateDb extends BaseDb {
   }
 
   async getByKey (key: string): Promise<State> {
+    await this.tilReady()
     const item: State = await this.getById(key)
     return this.normalizeValue(key, item)
   }

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -36,7 +36,6 @@ export default class Bridge extends ContractBase {
   bridgeDeployedBlockNumber: number
   l1CanonicalTokenAddress: string
   stateUpdateAddress: string
-  isFirstIteration: boolean = true
 
   constructor (bridgeContract: BridgeContract) {
     super(bridgeContract)
@@ -553,14 +552,6 @@ export default class Bridge extends ContractBase {
         options.cacheKey
       )
       state = await this.db.syncState.getByKey(cacheKey)
-    }
-
-    if (cacheKey && this.isFirstIteration && this.chainSlug === Chain.Optimism) {
-      await this.db.syncState.update(cacheKey, {
-        latestBlockSynced: 0,
-        timestamp: Date.now()
-      })
-      this.isFirstIteration = false
     }
 
     let {

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -36,6 +36,7 @@ export default class Bridge extends ContractBase {
   bridgeDeployedBlockNumber: number
   l1CanonicalTokenAddress: string
   stateUpdateAddress: string
+  isFirstIteration: boolean = true
 
   constructor (bridgeContract: BridgeContract) {
     super(bridgeContract)
@@ -552,6 +553,14 @@ export default class Bridge extends ContractBase {
         options.cacheKey
       )
       state = await this.db.syncState.getByKey(cacheKey)
+    }
+
+    if (cacheKey && this.isFirstIteration && this.chainSlug === Chain.Optimism) {
+      await this.db.syncState.update(cacheKey, {
+        latestBlockSynced: 0,
+        timestamp: Date.now()
+      })
+      this.isFirstIteration = false
     }
 
     let {


### PR DESCRIPTION
DO NOT MERGE.

This is an example PR to prep for the Optimism regenesis. If the code makes sense, we can cherrypick commits into the bonder from develop.

Changes are:
1. Update `bridgeDeployedBlockNumber` to `0` in `core`
2. Turn off Optimism watchers
3. On the first sync, reset the Optimism `latestBlockSynced` to `0` for just the first run
    * This is meant to be removed the next time the bonder restarts 