### PR TITLE
frontend: Disable Optimism during regenesis

### DIFF
--- a/packages/frontend/src/components/header/Header.tsx
+++ b/packages/frontend/src/components/header/Header.tsx
@@ -11,6 +11,7 @@ import HopLogoFullColor from 'src/assets/logos/hop-logo-full-color.svg'
 import { isMainnet } from 'src/config'
 import Settings from 'src/pages/Send/Settings'
 import WalletWarning from './WalletWarning'
+import Banner from 'src/components/Banner'
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -45,6 +46,7 @@ const Header: FC = () => {
 
   return (
     <>
+      <Banner>Optimism is undergoing regenesis. Sending from or to Optimism in temporarily disabled for the next few hours.</Banner>
       <Box className={styles.root} display="flex" alignItems="center">
         <Box display="flex" flexDirection="row" flex={1} justifyContent="flex-start">
           <Link to="/">

--- a/packages/frontend/src/config/mainnet.ts
+++ b/packages/frontend/src/config/mainnet.ts
@@ -46,6 +46,7 @@ export const networks: Networks = {
     nativeBridgeUrl: _networks.arbitrum.nativeBridgeUrl,
     waitConfirmations: _networks.arbitrum.waitConfirmations,
   },
+  /*
   optimism: {
     networkId: _networks.optimism.networkId.toString(),
     rpcUrls: _networks.optimism.rpcUrls,
@@ -54,6 +55,7 @@ export const networks: Networks = {
     nativeBridgeUrl: _networks.optimism.nativeBridgeUrl,
     waitConfirmations: _networks.optimism.waitConfirmations,
   },
+  */
   xdai: {
     networkId: _networks.xdai.networkId.toString(),
     rpcUrls: _networks.xdai.rpcUrls,


### PR DESCRIPTION
Do not merge until regenesis is about to occur (Nov 11 9am PT)

![DeepinScreenshot_select-area_20211110124840](https://user-images.githubusercontent.com/168240/141191137-ac9d0285-ee24-4a46-9303-9b7da5263ed5.png)

- Disables Optimism completely as an option
- Adds explainer banner