### PR TITLE
UI: smarter button states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ db_data
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vscode

--- a/packages/frontend/src/components/buttons/Button.tsx
+++ b/packages/frontend/src/components/buttons/Button.tsx
@@ -7,6 +7,7 @@ interface StyleProps {
   highlighted: boolean
   large: boolean
   flat: boolean
+  size?: number | string
 }
 
 interface StateProps {
@@ -76,6 +77,7 @@ const LargeButton: FC<ButtonProps> = props => {
     flat = false,
     disabled = false,
     loading = false,
+    size = 40,
     ...buttonProps
   } = props
   const styles = useStyles({ highlighted, large, flat })
@@ -90,7 +92,7 @@ const LargeButton: FC<ButtonProps> = props => {
       {children}
       {loading ? (
         <div className={styles.spinner}>
-          <CircularProgress />
+          <CircularProgress size={large ? '2rem' : size} />
         </div>
       ) : null}
     </MuiButton>

--- a/packages/frontend/src/components/txConfirm/AddLiquidity.tsx
+++ b/packages/frontend/src/components/txConfirm/AddLiquidity.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Button from 'src/components/buttons/Button'
 import { makeStyles } from '@material-ui/core/styles'
 import Token from 'src/models/Token'
 import Network from 'src/models/Network'
 import Typography from '@material-ui/core/Typography'
-import logger from 'src/logger'
 import { commafy } from 'src/utils'
+import { useSendingTransaction } from './useSendingTransaction'
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -36,16 +36,8 @@ interface Props {
 const AddLiquidity = (props: Props) => {
   const { token0, token1, onConfirm } = props
   const styles = useStyles()
-  const [sending, setSending] = useState<boolean>(false)
 
-  const handleSubmit = async () => {
-    try {
-      setSending(true)
-      onConfirm(true)
-    } catch (err) {
-      logger.error(err)
-    }
-  }
+  const { sending, handleSubmit } = useSendingTransaction({ onConfirm })
 
   return (
     <div className={styles.root}>

--- a/packages/frontend/src/components/txConfirm/AddLiquidity.tsx
+++ b/packages/frontend/src/components/txConfirm/AddLiquidity.tsx
@@ -45,7 +45,6 @@ const AddLiquidity = (props: Props) => {
     } catch (err) {
       logger.error(err)
     }
-    setSending(false)
   }
 
   return (

--- a/packages/frontend/src/components/txConfirm/Approval.tsx
+++ b/packages/frontend/src/components/txConfirm/Approval.tsx
@@ -4,8 +4,8 @@ import { makeStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Checkbox from '@material-ui/core/Checkbox'
-import logger from 'src/logger'
 import { commafy } from 'src/utils'
+import { useSendingTransaction } from './useSendingTransaction'
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -40,18 +40,10 @@ interface Props {
 const Approval = (props: Props) => {
   const { amount, tokenSymbol, onConfirm, tagline } = props
   const styles = useStyles()
-  const [sending, setSending] = useState<boolean>(false)
   const [approveAll, setApproveAll] = useState<boolean>(true)
   const showApproveAll = !!amount
 
-  const handleSubmit = async () => {
-    try {
-      setSending(true)
-      onConfirm(true, approveAll)
-    } catch (err) {
-      logger.error(err)
-    }
-  }
+  const { sending, handleSubmit } = useSendingTransaction({ onConfirm })
 
   const handleApproveAll = (event: ChangeEvent<HTMLInputElement>) => {
     const checked = event.target.checked
@@ -88,7 +80,7 @@ const Approval = (props: Props) => {
       <div className={styles.action}>
         <Button
           className={styles.sendButton}
-          onClick={handleSubmit}
+          onClick={() => handleSubmit(approveAll)}
           loading={sending}
           large
           highlighted

--- a/packages/frontend/src/components/txConfirm/Approval.tsx
+++ b/packages/frontend/src/components/txConfirm/Approval.tsx
@@ -51,7 +51,6 @@ const Approval = (props: Props) => {
     } catch (err) {
       logger.error(err)
     }
-    setSending(false)
   }
 
   const handleApproveAll = (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/frontend/src/components/txConfirm/ConfirmConvert.tsx
+++ b/packages/frontend/src/components/txConfirm/ConfirmConvert.tsx
@@ -31,7 +31,7 @@ interface Props {
   onConfirm: (confirmed: boolean) => void
 }
 
-const Convert = (props: Props) => {
+const ConfirmConvert = (props: Props) => {
   const { source, dest, onConfirm } = props
   const styles = useStyles()
   const [sending, setSending] = useState<boolean>(false)
@@ -69,4 +69,4 @@ const Convert = (props: Props) => {
   )
 }
 
-export default Convert
+export default ConfirmConvert

--- a/packages/frontend/src/components/txConfirm/ConfirmConvert.tsx
+++ b/packages/frontend/src/components/txConfirm/ConfirmConvert.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Button from 'src/components/buttons/Button'
 import { makeStyles } from '@material-ui/core/styles'
 import Token from 'src/models/Token'
 import Typography from '@material-ui/core/Typography'
-import logger from 'src/logger'
 import { commafy } from 'src/utils'
+import { useSendingTransaction } from './useSendingTransaction'
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -34,16 +34,8 @@ interface Props {
 const ConfirmConvert = (props: Props) => {
   const { source, dest, onConfirm } = props
   const styles = useStyles()
-  const [sending, setSending] = useState<boolean>(false)
 
-  const handleSubmit = async () => {
-    try {
-      setSending(true)
-      onConfirm(true)
-    } catch (err) {
-      logger.error(err)
-    }
-  }
+  const { sending, handleSubmit } = useSendingTransaction({ onConfirm })
 
   return (
     <div className={styles.root}>

--- a/packages/frontend/src/components/txConfirm/ConfirmConvert.tsx
+++ b/packages/frontend/src/components/txConfirm/ConfirmConvert.tsx
@@ -43,7 +43,6 @@ const ConfirmConvert = (props: Props) => {
     } catch (err) {
       logger.error(err)
     }
-    setSending(false)
   }
 
   return (

--- a/packages/frontend/src/components/txConfirm/ConfirmSend.tsx
+++ b/packages/frontend/src/components/txConfirm/ConfirmSend.tsx
@@ -42,7 +42,7 @@ interface Props {
   onConfirm: (confirmed: boolean) => void
 }
 
-const Send = (props: Props) => {
+const ConfirmSend = (props: Props) => {
   const { customRecipient, source, dest, onConfirm } = props
   const styles = useStyles()
   const [sending, setSending] = useState<boolean>(false)
@@ -54,7 +54,7 @@ const Send = (props: Props) => {
     } catch (err) {
       logger.error(err)
     }
-    setSending(false)
+    // setSending(false)
   }
 
   let warning = ''
@@ -84,6 +84,7 @@ const Send = (props: Props) => {
           className={styles.sendButton}
           onClick={handleSubmit}
           loading={sending}
+          disabled={sending}
           large
           highlighted
         >
@@ -94,4 +95,4 @@ const Send = (props: Props) => {
   )
 }
 
-export default Send
+export default ConfirmSend

--- a/packages/frontend/src/components/txConfirm/ConfirmSend.tsx
+++ b/packages/frontend/src/components/txConfirm/ConfirmSend.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Button from 'src/components/buttons/Button'
 import Alert from 'src/components/alert/Alert'
 import { makeStyles } from '@material-ui/core/styles'
 import Token from 'src/models/Token'
 import Network from 'src/models/Network'
 import Typography from '@material-ui/core/Typography'
-import logger from 'src/logger'
 import { commafy } from 'src/utils'
 import Address from 'src/models/Address'
+import { useSendingTransaction } from './useSendingTransaction'
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -45,16 +45,8 @@ interface Props {
 const ConfirmSend = (props: Props) => {
   const { customRecipient, source, dest, onConfirm } = props
   const styles = useStyles()
-  const [sending, setSending] = useState<boolean>(false)
 
-  const handleSubmit = async () => {
-    try {
-      setSending(true)
-      onConfirm(true)
-    } catch (err) {
-      logger.error(err)
-    }
-  }
+  const { sending, handleSubmit } = useSendingTransaction({ onConfirm })
 
   let warning = ''
   if (customRecipient && !dest?.network?.isLayer1) {

--- a/packages/frontend/src/components/txConfirm/ConfirmSend.tsx
+++ b/packages/frontend/src/components/txConfirm/ConfirmSend.tsx
@@ -54,7 +54,6 @@ const ConfirmSend = (props: Props) => {
     } catch (err) {
       logger.error(err)
     }
-    // setSending(false)
   }
 
   let warning = ''

--- a/packages/frontend/src/components/txConfirm/ConfirmSend.tsx
+++ b/packages/frontend/src/components/txConfirm/ConfirmSend.tsx
@@ -75,7 +75,6 @@ const ConfirmSend = (props: Props) => {
           className={styles.sendButton}
           onClick={handleSubmit}
           loading={sending}
-          disabled={sending}
           large
           highlighted
         >

--- a/packages/frontend/src/components/txConfirm/ConfirmStake.tsx
+++ b/packages/frontend/src/components/txConfirm/ConfirmStake.tsx
@@ -38,7 +38,6 @@ const ConfirmStake = (props: Props) => {
     } catch (err) {
       logger.error(err)
     }
-    setSending(false)
   }
 
   return (

--- a/packages/frontend/src/components/txConfirm/ConfirmStake.tsx
+++ b/packages/frontend/src/components/txConfirm/ConfirmStake.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import { Token } from '@hop-protocol/sdk'
 import Button from 'src/components/buttons/Button'
-import logger from 'src/logger'
 import { commafy } from 'src/utils'
+import { useSendingTransaction } from './useSendingTransaction'
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -29,16 +29,8 @@ interface Props {
 const ConfirmStake = (props: Props) => {
   const { amount, token, onConfirm } = props
   const styles = useStyles()
-  const [sending, setSending] = useState<boolean>(false)
 
-  const handleSubmit = async () => {
-    try {
-      setSending(true)
-      onConfirm(true)
-    } catch (err) {
-      logger.error(err)
-    }
-  }
+  const { sending, handleSubmit } = useSendingTransaction({ onConfirm })
 
   return (
     <div className={styles.root}>

--- a/packages/frontend/src/components/txConfirm/ConfirmStake.tsx
+++ b/packages/frontend/src/components/txConfirm/ConfirmStake.tsx
@@ -26,7 +26,7 @@ interface Props {
   onConfirm: (confirmed: boolean) => void
 }
 
-const Stake = (props: Props) => {
+const ConfirmStake = (props: Props) => {
   const { amount, token, onConfirm } = props
   const styles = useStyles()
   const [sending, setSending] = useState<boolean>(false)
@@ -63,4 +63,4 @@ const Stake = (props: Props) => {
   )
 }
 
-export default Stake
+export default ConfirmStake

--- a/packages/frontend/src/components/txConfirm/TxConfirm.tsx
+++ b/packages/frontend/src/components/txConfirm/TxConfirm.tsx
@@ -2,10 +2,10 @@ import React, { FC } from 'react'
 import Modal from 'src/components/modal/Modal'
 import Approval from 'src/components/txConfirm/Approval'
 import ConfirmSend from 'src/components/txConfirm/ConfirmSend'
-import Convert from 'src/components/txConfirm/Convert'
+import ConfirmConvert from 'src/components/txConfirm/ConfirmConvert'
 import AddLiquidity from 'src/components/txConfirm/AddLiquidity'
 import RemoveLiquidity from 'src/components/txConfirm/RemoveLiquidity'
-import Stake from 'src/components/txConfirm/Stake'
+import ConfirmStake from 'src/components/txConfirm/ConfirmStake'
 import WithdrawStake from 'src/components/txConfirm/WithdrawStake'
 import WrapToken from 'src/components/txConfirm/WrapToken'
 import UnwrapToken from 'src/components/txConfirm/UnwrapToken'
@@ -21,10 +21,10 @@ const TxConfirm: FC = props => {
   const components: { [key: string]: FC<any> } = {
     approval: Approval,
     send: ConfirmSend,
-    convert: Convert,
+    convert: ConfirmConvert,
     addLiquidity: AddLiquidity,
     removeLiquidity: RemoveLiquidity,
-    stake: Stake,
+    stake: ConfirmStake,
     withdrawStake: WithdrawStake,
     wrapToken: WrapToken,
     unwrapToken: UnwrapToken,

--- a/packages/frontend/src/components/txConfirm/TxConfirm.tsx
+++ b/packages/frontend/src/components/txConfirm/TxConfirm.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import Modal from 'src/components/modal/Modal'
 import Approval from 'src/components/txConfirm/Approval'
-import Send from 'src/components/txConfirm/Send'
+import ConfirmSend from 'src/components/txConfirm/ConfirmSend'
 import Convert from 'src/components/txConfirm/Convert'
 import AddLiquidity from 'src/components/txConfirm/AddLiquidity'
 import RemoveLiquidity from 'src/components/txConfirm/RemoveLiquidity'
@@ -20,7 +20,7 @@ const TxConfirm: FC = props => {
   const { kind, inputProps, onConfirm } = txConfirmParams
   const components: { [key: string]: FC<any> } = {
     approval: Approval,
-    send: Send,
+    send: ConfirmSend,
     convert: Convert,
     addLiquidity: AddLiquidity,
     removeLiquidity: RemoveLiquidity,

--- a/packages/frontend/src/components/txConfirm/UnwrapToken.tsx
+++ b/packages/frontend/src/components/txConfirm/UnwrapToken.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Button from 'src/components/buttons/Button'
 import { makeStyles } from '@material-ui/core/styles'
 import Token from 'src/models/Token'
 import Network from 'src/models/Network'
 import Typography from '@material-ui/core/Typography'
-import logger from 'src/logger'
 import { commafy } from 'src/utils'
+import { useSendingTransaction } from './useSendingTransaction'
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -35,16 +35,8 @@ interface Props {
 const UnwrapToken = (props: Props) => {
   const { token, onConfirm } = props
   const styles = useStyles()
-  const [sending, setSending] = useState<boolean>(false)
 
-  const handleSubmit = async () => {
-    try {
-      setSending(true)
-      onConfirm(true)
-    } catch (err) {
-      logger.error(err)
-    }
-  }
+  const { sending, handleSubmit } = useSendingTransaction({ onConfirm })
 
   return (
     <div className={styles.root}>

--- a/packages/frontend/src/components/txConfirm/UnwrapToken.tsx
+++ b/packages/frontend/src/components/txConfirm/UnwrapToken.tsx
@@ -44,7 +44,6 @@ const UnwrapToken = (props: Props) => {
     } catch (err) {
       logger.error(err)
     }
-    setSending(false)
   }
 
   return (

--- a/packages/frontend/src/components/txConfirm/WrapToken.tsx
+++ b/packages/frontend/src/components/txConfirm/WrapToken.tsx
@@ -44,7 +44,6 @@ const WrapToken = (props: Props) => {
     } catch (err) {
       logger.error(err)
     }
-    setSending(false)
   }
 
   return (

--- a/packages/frontend/src/components/txConfirm/WrapToken.tsx
+++ b/packages/frontend/src/components/txConfirm/WrapToken.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Button from 'src/components/buttons/Button'
 import { makeStyles } from '@material-ui/core/styles'
 import Token from 'src/models/Token'
 import Network from 'src/models/Network'
 import Typography from '@material-ui/core/Typography'
-import logger from 'src/logger'
 import { commafy } from 'src/utils'
+import { useSendingTransaction } from './useSendingTransaction'
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -35,16 +35,8 @@ interface Props {
 const WrapToken = (props: Props) => {
   const { token, onConfirm } = props
   const styles = useStyles()
-  const [sending, setSending] = useState<boolean>(false)
 
-  const handleSubmit = async () => {
-    try {
-      setSending(true)
-      onConfirm(true)
-    } catch (err) {
-      logger.error(err)
-    }
-  }
+  const { sending, handleSubmit } = useSendingTransaction({ onConfirm })
 
   return (
     <div className={styles.root}>

--- a/packages/frontend/src/components/txConfirm/useSendingTransaction.ts
+++ b/packages/frontend/src/components/txConfirm/useSendingTransaction.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+import logger from 'src/logger'
+
+interface SendingTransaction {
+  onConfirm: (confirmed: boolean, params?: any) => void
+}
+
+export function useSendingTransaction(props: SendingTransaction) {
+  const { onConfirm } = props
+
+  const [sending, setSending] = useState<boolean>(false)
+
+  async function handleSubmit(opts?: any) {
+    try {
+      setSending(true)
+      onConfirm(true, opts)
+    } catch (err) {
+      logger.error(err)
+      setSending(false)
+    }
+  }
+
+  return {
+    sending,
+    setSending,
+    handleSubmit,
+  }
+}

--- a/packages/frontend/src/pages/Send/Send.tsx
+++ b/packages/frontend/src/pages/Send/Send.tsx
@@ -476,19 +476,33 @@ const Send: FC = () => {
     setCustomRecipient(value)
   }
 
-  const validFormFields = !!(
-    fromTokenAmount &&
-    toTokenAmount &&
-    rate &&
-    enoughBalance &&
-    !needsTokenForFee &&
-    isLiquidityAvailable &&
-    !checkingLiquidity &&
-    estimatedReceived?.gt(0)
-  )
-
   const approveButtonActive = !needsTokenForFee && !unsupportedAsset && needsApproval
-  const sendButtonActive = validFormFields && !unsupportedAsset && !needsApproval
+
+  const sendButtonActive = useMemo(() => {
+    return !!(
+      !approveButtonActive &&
+      !checkingLiquidity &&
+      !loadingToBalance &&
+      !loadingSendData &&
+      fromTokenAmount &&
+      toTokenAmount &&
+      rate &&
+      enoughBalance &&
+      isLiquidityAvailable &&
+      estimatedReceived?.gt(0)
+    )
+  }, [
+    approveButtonActive,
+    checkingLiquidity,
+    loadingToBalance,
+    loadingSendData,
+    fromTokenAmount,
+    toTokenAmount,
+    rate,
+    enoughBalance,
+    isLiquidityAvailable,
+    estimatedReceived,
+  ])
 
   return (
     <Box display="flex" flexDirection="column" alignItems="center">


### PR DESCRIPTION
this pr prevents accidental double clicks for the modal components in `TxConfirm`.

additionally, readability is improved for the `Send` component, and tx confirm component names which were previously named the same as others are renamed with the prefix `Confirm-`.