### PR TITLE
hop-node: do not block CLI bond-withdrawal command

### DIFF
--- a/packages/hop-node/src/cli/bondWithdrawal.ts
+++ b/packages/hop-node/src/cli/bondWithdrawal.ts
@@ -54,7 +54,12 @@ program
         throw new Error('watcher not found')
       }
 
-      await watcher.checkTransferId(transferId)
+      const dbTransfer: any = await watcher.db.transfers.getByTransferId(transferId)
+      if (!dbTransfer) {
+        throw new Error('TransferId does not exist in the DB')
+      }
+      dbTransfer.attemptSwap = watcher.bridge.shouldAttemptSwap(dbTransfer.amountOutMin!, dbTransfer.deadline!)
+      await watcher.sendBondWithdrawalTx(dbTransfer)
 
       process.exit(0)
     } catch (err) {


### PR DESCRIPTION
A change we made a while ago blocked the ability to bond withdrawals with the CLI. This was because the bonder fee check needed the context of a `gasCost` DB, however the CLI should not care about that, I believe.

This PR logically reorders a few items in the `bondWithdrawalWatcher` and calls `sendBondWithdrawalTx()` directly in the CLI command.