### PR TITLE
hop-node: introduce a per-asset per-chain fee structure

### DIFF
--- a/packages/hop-node/src/config/config.ts
+++ b/packages/hop-node/src/config/config.ts
@@ -134,30 +134,30 @@ export const config: Config = {
   stateUpdateAddress: '',
   fees: {
     USDC: {
-      ethereum: 14,
-      polygon: 14,
+      ethereum: 18,
+      polygon: 18,
       xdai: 25,
-      optimism: 14,
-      arbitrum: 14
+      optimism: 18,
+      arbitrum: 18
     },
     USDT: {
-      ethereum: 18,
-      polygon: 18,
-      xdai: 25,
-      optimism: 18,
-      arbitrum: 18
+      ethereum: 25,
+      polygon: 25,
+      xdai: 30,
+      optimism: 25,
+      arbitrum: 25
     },
     DAI: {
-      ethereum: 18,
-      polygon: 18,
-      xdai: 25,
-      optimism: 18,
-      arbitrum: 18
+      ethereum: 25,
+      polygon: 25,
+      xdai: 30,
+      optimism: 25,
+      arbitrum: 25
     },
     MATIC: {
-      ethereum: 18,
-      polygon: 18,
-      xdai: 25,
+      ethereum: 25,
+      polygon: 25,
+      xdai: 30,
       optimism: 0,
       arbitrum: 0
     },
@@ -169,11 +169,11 @@ export const config: Config = {
       arbitrum: 9
     },
     WBTC: {
-      ethereum: 18,
-      polygon: 18,
-      xdai: 25,
-      optimism: 18,
-      arbitrum: 18
+      ethereum: 25,
+      polygon: 25,
+      xdai: 30,
+      optimism: 25,
+      arbitrum: 25
     }
   },
   db: {

--- a/packages/hop-node/src/config/config.ts
+++ b/packages/hop-node/src/config/config.ts
@@ -63,10 +63,13 @@ type MetricsConfig = {
   enabled: boolean
   port?: number
 }
+
 type Bps = {
-  anyToxDai?: number
-  L2ToL1: number
-  L2ToL2: number
+  ethereum: number
+  polygon: number
+  xdai: number
+  optimism: number
+  arbitrum: number
 }
 
 export type Fees = Record<string, Bps>
@@ -131,28 +134,46 @@ export const config: Config = {
   stateUpdateAddress: '',
   fees: {
     USDC: {
-      L2ToL1: 10,
-      L2ToL2: 10
+      ethereum: 14,
+      polygon: 14,
+      xdai: 25,
+      optimism: 14,
+      arbitrum: 14
     },
     USDT: {
-      L2ToL1: 10,
-      L2ToL2: 10
+      ethereum: 18,
+      polygon: 18,
+      xdai: 25,
+      optimism: 18,
+      arbitrum: 18
     },
     DAI: {
-      L2ToL1: 10,
-      L2ToL2: 10
+      ethereum: 18,
+      polygon: 18,
+      xdai: 25,
+      optimism: 18,
+      arbitrum: 18
     },
     MATIC: {
-      L2ToL1: 10,
-      L2ToL2: 10
+      ethereum: 18,
+      polygon: 18,
+      xdai: 25,
+      optimism: 0,
+      arbitrum: 0
     },
     ETH: {
-      L2ToL1: 10,
-      L2ToL2: 10
+      ethereum: 8,
+      polygon: 9,
+      xdai: 18,
+      optimism: 9,
+      arbitrum: 9
     },
     WBTC: {
-      L2ToL1: 10,
-      L2ToL2: 10
+      ethereum: 18,
+      polygon: 18,
+      xdai: 25,
+      optimism: 18,
+      arbitrum: 18
     }
   },
   db: {

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -723,14 +723,7 @@ export default class Bridge extends ContractBase {
       throw new Error(`fee config not found for ${this.tokenSymbol}`)
     }
 
-    let bonderFeeBps = fees.L2ToL2
-    if (destinationChain === Chain.Ethereum) {
-      bonderFeeBps = fees.L2ToL1
-    }
-    if (destinationChain === Chain.xDai && fees.anyToxDai) {
-      bonderFeeBps = fees.anyToxDai
-    }
-
+    const bonderFeeBps = fees[destinationChain]
     const minBonderFeeRelative = amountIn.mul(bonderFeeBps).div(10000)
     let minBonderFee = minBonderFeeRelative.gt(minBonderFeeAbsolute)
       ? minBonderFeeRelative

--- a/packages/sdk/src/Base.ts
+++ b/packages/sdk/src/Base.ts
@@ -2,6 +2,7 @@ import memoize from 'fast-memoize'
 import { Addresses } from '@hop-protocol/core/addresses'
 import { BigNumber, BigNumberish, Contract, Signer, constants, providers } from 'ethers'
 import { Chain, Token as TokenModel } from './models'
+import { Chain as ChainEnum } from './constants'
 import { TChain, TProvider, TToken } from './types'
 import { config, metadata } from './config'
 import { getContractFactory, predeploys } from '@eth-optimism/contracts'
@@ -451,14 +452,8 @@ class Base {
     if (!fees) {
       throw new Error('fee data not found')
     }
-    let feeBps = fees?.L2ToL2
-    if (destinationChain.isL1) {
-      feeBps = fees?.L2ToL1
-    }
-    if (destinationChain.equals(Chain.xDai) && fees?.anyToxDai) {
-      feeBps = fees?.anyToxDai
-    }
 
+    const feeBps: number = fees[destinationChain.slug as ChainEnum]
     return feeBps
   }
 

--- a/packages/sdk/src/config/config.ts
+++ b/packages/sdk/src/config/config.ts
@@ -35,30 +35,30 @@ type Bps = {
 
 const fees: Record<string, Bps> = {
   USDC: {
-    ethereum: 14,
-    polygon: 14,
+    ethereum: 18,
+    polygon: 18,
     xdai: 25,
-    optimism: 14,
-    arbitrum: 14
+    optimism: 18,
+    arbitrum: 18
   },
   USDT: {
-    ethereum: 18,
-    polygon: 18,
-    xdai: 25,
-    optimism: 18,
-    arbitrum: 18
+    ethereum: 25,
+    polygon: 25,
+    xdai: 30,
+    optimism: 25,
+    arbitrum: 25
   },
   DAI: {
-    ethereum: 18,
-    polygon: 18,
-    xdai: 25,
-    optimism: 18,
-    arbitrum: 18
+    ethereum: 25,
+    polygon: 25,
+    xdai: 30,
+    optimism: 25,
+    arbitrum: 25
   },
   MATIC: {
-    ethereum: 18,
-    polygon: 18,
-    xdai: 25,
+    ethereum: 25,
+    polygon: 25,
+    xdai: 30,
     optimism: 0,
     arbitrum: 0
   },
@@ -70,11 +70,11 @@ const fees: Record<string, Bps> = {
     arbitrum: 9
   },
   WBTC: {
-    ethereum: 18,
-    polygon: 18,
-    xdai: 25,
-    optimism: 18,
-    arbitrum: 18
+    ethereum: 25,
+    polygon: 25,
+    xdai: 30,
+    optimism: 25,
+    arbitrum: 25
   }
 }
 

--- a/packages/sdk/src/config/config.ts
+++ b/packages/sdk/src/config/config.ts
@@ -26,36 +26,55 @@ const bonders: { [network: string]: { [token: string]: string[] } } = {
 }
 
 type Bps = {
-  L2ToL1: number
-  L2ToL2: number
-  anyToxDai: number
+  ethereum: number
+  polygon: number
+  xdai: number
+  optimism: number
+  arbitrum: number
 }
 
 const fees: Record<string, Bps> = {
   USDC: {
-    L2ToL1: 14,
-    L2ToL2: 14,
-    anyToxDai: 25
+    ethereum: 14,
+    polygon: 14,
+    xdai: 25,
+    optimism: 14,
+    arbitrum: 14
   },
   USDT: {
-    L2ToL1: 18,
-    L2ToL2: 18,
-    anyToxDai: 18
+    ethereum: 18,
+    polygon: 18,
+    xdai: 25,
+    optimism: 18,
+    arbitrum: 18
   },
   DAI: {
-    L2ToL1: 18,
-    L2ToL2: 18,
-    anyToxDai: 18
+    ethereum: 18,
+    polygon: 18,
+    xdai: 25,
+    optimism: 18,
+    arbitrum: 18
   },
   MATIC: {
-    L2ToL1: 18,
-    L2ToL2: 18,
-    anyToxDai: 18
+    ethereum: 18,
+    polygon: 18,
+    xdai: 25,
+    optimism: 0,
+    arbitrum: 0
   },
   ETH: {
-    L2ToL1: 8,
-    L2ToL2: 9,
-    anyToxDai: 18
+    ethereum: 8,
+    polygon: 9,
+    xdai: 18,
+    optimism: 9,
+    arbitrum: 9
+  },
+  WBTC: {
+    ethereum: 18,
+    polygon: 18,
+    xdai: 25,
+    optimism: 18,
+    arbitrum: 18
   }
 }
 


### PR DESCRIPTION
Allows the SDK and the bonder to define fees on a per-asset, per-chain basis