### PR TITLE
sdk: fix gas estimation

### DIFF
--- a/packages/sdk/src/HopBridge.ts
+++ b/packages/sdk/src/HopBridge.ts
@@ -1632,9 +1632,13 @@ class HopBridge extends Base {
     ]
 
     if (estimateGasOnly) {
-      return l1Bridge.estimateGas.sendToL2(
-        ...txOptions
-      )
+      try {
+        return l1Bridge.estimateGas.sendToL2(
+          ...txOptions
+        )
+      } catch (error) {
+        throw new Error(error.message)
+      }
     }
 
     return l1Bridge.sendToL2(
@@ -1720,10 +1724,14 @@ class HopBridge extends Base {
       ]
 
       if (estimateGasOnly) {
-        return ammWrapper.estimateGas.swapAndSend(
-          ...txOptions,
-          ...additionalOptions
-        )
+        try {
+          return ammWrapper.estimateGas.swapAndSend(
+            ...txOptions,
+            ...additionalOptions
+          )
+        } catch (error) {
+          throw new Error(error.message)
+        }
       }
 
       return ammWrapper.swapAndSend(
@@ -1810,7 +1818,11 @@ class HopBridge extends Base {
     ]
 
     if (estimateGasOnly) {
-      return ammWrapper.estimateGas.swapAndSend(...txOptions)
+      try {
+        return ammWrapper.estimateGas.swapAndSend(...txOptions)
+      } catch (error) {
+        throw new Error(error.message)
+      }
     }
 
     return ammWrapper.swapAndSend(...txOptions)

--- a/packages/sdk/src/HopBridge.ts
+++ b/packages/sdk/src/HopBridge.ts
@@ -1719,7 +1719,8 @@ class HopBridge extends Base {
         destinationDeadline,
         {
           ...(await this.txOverrides(sourceChain)),
-          value: isNativeToken ? amount : undefined
+          value: isNativeToken ? amount : undefined,
+          from: this.getSignerAddress(),
         }
       ]
 
@@ -1813,7 +1814,8 @@ class HopBridge extends Base {
       destinationDeadline,
       {
         ...(await this.txOverrides(sourceChain)),
-        value: isNativeToken ? amount : undefined
+        value: isNativeToken ? amount : undefined,
+        from: this.getSignerAddress(),
       }
     ]
 
@@ -1888,7 +1890,8 @@ class HopBridge extends Base {
         bonderFee,
         {
           ...(await this.txOverrides(Chain.Ethereum)),
-          value: isNativeToken ? tokenAmount : undefined
+          value: isNativeToken ? tokenAmount : undefined,
+          from: this.getSignerAddress(),
         }
       ]
 


### PR DESCRIPTION
previously, if `sourceChain` was optimism, gas estimations would fail. setting the `from` address resolved this. i'm guessing the optimism rpc requires a `from` field when calling `eth_estimateGas`.