### PR TITLE
Use ENS name as account identifier if it exists

### DIFF
--- a/packages/frontend/src/components/header/TxPill.tsx
+++ b/packages/frontend/src/components/header/TxPill.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import { ethers } from 'ethers';
 import { makeStyles } from '@material-ui/core/styles'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import { useApp } from 'src/contexts/AppContext'

--- a/packages/frontend/src/components/header/TxPill.tsx
+++ b/packages/frontend/src/components/header/TxPill.tsx
@@ -4,6 +4,7 @@ import CircularProgress from '@material-ui/core/CircularProgress'
 import { useApp } from 'src/contexts/AppContext'
 import { useWeb3Context } from 'src/contexts/Web3Context'
 import { StyledButton } from '../buttons/StyledButton'
+import { getProviderByNetworkName } from "src/utils/getProvider"
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -26,10 +27,11 @@ const useStyles = makeStyles(theme => ({
 const TxPill = () => {
   const app = useApp()
   const { accountDetails } = app
-  const { address, provider } = useWeb3Context()
+  const { address } = useWeb3Context()
   const transactions = app?.txHistory?.transactions
   const styles = useStyles()
   const [numPendingTxs, setNumPendingTxs] = useState(0)
+  const provider = getProviderByNetworkName('ethereum')
   const [ensName, setENSName] = useState<string | null>(null);
 
   const handleClick = () => {
@@ -47,9 +49,9 @@ const TxPill = () => {
 
   useEffect(() => {
     if (address) {
-      provider?.lookupAddress(address.toString()).then(setENSName);
+      provider.lookupAddress(address.toString()).then(setENSName)
     }
-  })
+  }, [address, provider])
 
   return (
     <div className={styles.root}>

--- a/packages/frontend/src/components/header/TxPill.tsx
+++ b/packages/frontend/src/components/header/TxPill.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { ethers } from 'ethers';
 import { makeStyles } from '@material-ui/core/styles'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import { useApp } from 'src/contexts/AppContext'
@@ -26,10 +27,11 @@ const useStyles = makeStyles(theme => ({
 const TxPill = () => {
   const app = useApp()
   const { accountDetails } = app
-  const { address } = useWeb3Context()
+  const { address, provider } = useWeb3Context()
   const transactions = app?.txHistory?.transactions
   const styles = useStyles()
   const [numPendingTxs, setNumPendingTxs] = useState(0)
+  const [ensName, setENSName] = useState<string | null>(null);
 
   const handleClick = () => {
     accountDetails?.show(true)
@@ -44,6 +46,12 @@ const TxPill = () => {
     }
   }, [transactions])
 
+  useEffect(() => {
+    if (address) {
+      provider?.lookupAddress(address.toString()).then(setENSName);
+    }
+  })
+
   return (
     <div className={styles.root}>
       {numPendingTxs > 0 ? (
@@ -52,7 +60,7 @@ const TxPill = () => {
         </StyledButton>
       ) : (
         <StyledButton flat onClick={handleClick} boxShadow={0} fontSize={[0, 0, 1]}>
-          {address?.truncate()}
+          {ensName || address?.truncate()}
         </StyledButton>
       )}
     </div>


### PR DESCRIPTION
Show ENS name instead of truncated address in transactions pill if one exists for the address.

Before
<img width="476" alt="Screen Shot 2021-12-12 at 12 04 05 AM" src="https://user-images.githubusercontent.com/6640905/145705101-6f474a0b-9225-4507-b31f-2f6257e9bc58.png">

After
<img width="490" alt="Screen Shot 2021-12-12 at 12 03 50 AM" src="https://user-images.githubusercontent.com/6640905/145705105-30e56d55-56c5-4f9d-8ae4-722c2db40f0e.png">
