### PR TITLE
Feature/post pr updates

### DIFF
--- a/packages/hop-node/src/watchers/ChallengeWatcher.ts
+++ b/packages/hop-node/src/watchers/ChallengeWatcher.ts
@@ -80,12 +80,12 @@ class ChallengeWatcher extends BaseWatcher {
     if (!tx) {
       throw new Error('expected transaction object')
     }
+
     const { destinationChainId } = await l1Bridge.decodeBondTransferRootCalldata(tx.data)
-    const transferRootCommittedAt = await l1Bridge.getTransferRootCommittedAt(
+    const isTransferRootIdConfirmed = await l1Bridge.isTransferRootIdConfirmed(
       destinationChainId, transferRootId
     )
-    const isRootHashConfirmed = !!transferRootCommittedAt
-    if (isRootHashConfirmed) {
+    if (isTransferRootIdConfirmed) {
       logger.info('rootHash is already confirmed on L1')
       await this.db.transferRoots.update(transferRootId, {
         confirmed: true

--- a/packages/hop-node/src/watchers/ChallengeWatcher.ts
+++ b/packages/hop-node/src/watchers/ChallengeWatcher.ts
@@ -62,7 +62,7 @@ class ChallengeWatcher extends BaseWatcher {
 
     const { transferRootHash, totalAmount } = await this.db.transferRoots.getByTransferRootId(transferRootId)
     logger.debug('Challenging transfer root', transferRootId)
-    logger.debug('transferRootId:', transferRootId)
+    logger.debug('transferRootHash:', transferRootHash)
     logger.debug('totalAmount:', this.bridge.formatUnits(totalAmount!)) // eslint-disable-line @typescript-eslint/no-non-null-assertion
     logger.debug('transferRootId:', transferRootId)
 

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -249,9 +249,10 @@ class SyncWatcher extends BaseWatcher {
       return options
     }
 
+    const transferRootInitialEventPromises: Array<Promise<any>> = []
     if (this.isL1) {
       const l1Bridge = this.bridge as L1Bridge
-      promises.push(
+      transferRootInitialEventPromises.push(
         l1Bridge.mapTransferRootBondedEvents(
           async (event: TransferRootBondedEvent) => {
             return await this.handleTransferRootBondedEvent(event)
@@ -279,7 +280,6 @@ class SyncWatcher extends BaseWatcher {
       )
     }
 
-    const transfersCommittedPromises: Array<Promise<any>> = []
     if (!this.isL1) {
       const l2Bridge = this.bridge as L2Bridge
       promises.push(
@@ -291,7 +291,7 @@ class SyncWatcher extends BaseWatcher {
         )
       )
 
-      transfersCommittedPromises.push(
+      transferRootInitialEventPromises.push(
         l2Bridge.mapTransfersCommittedEvents(
           async (event: TransfersCommittedEvent) => {
             return await Promise.all([
@@ -323,7 +323,7 @@ class SyncWatcher extends BaseWatcher {
     )
 
     promises.push(
-      Promise.all(transferSpentPromises.concat(transfersCommittedPromises))
+      Promise.all(transferSpentPromises.concat(transferRootInitialEventPromises))
         .then(async () => {
         // This must be executed after the Withdrew and WithdrawalBonded event handlers
         // on initial sync since it relies on data from those handlers.

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -385,14 +385,6 @@ class SyncWatcher extends BaseWatcher {
     try {
       const { transactionHash, transactionIndex } = event
       const blockNumber: number = event.blockNumber
-      if (!transactionHash) {
-        logger.error('event transaction hash not found')
-        return
-      }
-      if (!blockNumber) {
-        logger.error('event block number not found')
-        return
-      }
       const l2Bridge = this.bridge as L2Bridge
       const destinationChainId = Number(destinationChainIdBn.toString())
       const sourceChainId = await l2Bridge.getChainId()
@@ -1021,11 +1013,7 @@ class SyncWatcher extends BaseWatcher {
       totalBondsSettled
     } = event.args
     const dbTransferRoot = await this.db.transferRoots.getByTransferRootHash(transferRootHash)
-    if (!dbTransferRoot?.transferRootId) {
-      this.logger.error(`expected db item for transfer root hash "${transferRootHash}"`)
-      return
-    }
-    const { transferRootId } = dbTransferRoot
+    const transferRootId = dbTransferRoot?.transferRootId!
     const logger = this.logger.create({ root: transferRootId })
 
     logger.debug('handling MultipleWithdrawalsSettled event')


### PR DESCRIPTION
Some clean up after resettle PR and transferRootId PR have been merged. Two bigger items:

1. Added `mapTransferRootBondedEvents()` to the array of promises that need to be completed prior to running `mapMultipleWithdrawalsSettledEvents()`. This is needed because, technically, the `TransferRootBonded` event can be seen prior to the `TransfersCommitted` event, which would not work without serializing as seen below.
2. Removed return statements from `handleTransferSentEvent()`. It definitely makes sense here because the two items we were `return`ing on will always exist in the event data that we are reading, so those were never going to be reached. 
3. Re-introduced a `throw` in the `handleMultipleWithdrawalsSettledEvent()` function (accidentally pushed it to develop [here](https://github.com/hop-protocol/hop/commit/d814bb716ff0d5550c1b3729304f10dcae615474)). I think you were correct originally and this is a good throw. Ideally, this never happens because we either see the `TransfersCommitted` event or the `TransferRootBonded` event first. However, if we were to completely miss one of those events for some reason (i.e. RPC doesn't give it to us, or we have a bug in our code), then I believe we should explicitly fail in order to investigate instead of silently "missing" the event. Happy to hear any thoughts you have.