### PR TITLE
hop-node: read existing DB entry before getting timestamped key

### DIFF
--- a/packages/hop-node/src/db/TransferRootsDb.ts
+++ b/packages/hop-node/src/db/TransferRootsDb.ts
@@ -312,7 +312,9 @@ class TransferRootsDb extends BaseDb {
       return
     }
     const transferRootId = transferRoot.transferRootId
-    const key = this.getTimestampedKey(transferRoot)
+    const dbTransferRoot = this.getById(transferRootId!)
+    const combinedData = Object.assign({}, dbTransferRoot, transferRoot)
+    const key = this.getTimestampedKey(combinedData)
     if (!key) {
       this.logger.warn('expected timestamped key. incomplete transfer root:', JSON.stringify(transferRoot))
       return

--- a/packages/hop-node/src/db/TransferRootsDb.ts
+++ b/packages/hop-node/src/db/TransferRootsDb.ts
@@ -312,7 +312,7 @@ class TransferRootsDb extends BaseDb {
       return
     }
     const transferRootId = transferRoot.transferRootId
-    const dbTransferRoot = this.getById(transferRootId!)
+    const dbTransferRoot = await this.getById(transferRootId!)
     const combinedData = Object.assign({}, dbTransferRoot, transferRoot)
     const key = this.getTimestampedKey(combinedData)
     if (!key) {

--- a/packages/hop-node/src/db/TransfersDb.ts
+++ b/packages/hop-node/src/db/TransfersDb.ts
@@ -177,7 +177,9 @@ class TransfersDb extends BaseDb {
       return
     }
     const transferId = transfer.transferId
-    const key = this.getTimestampedKey(transfer)
+    const dbTransfer = this.getById(transferId!)
+    const combinedData = Object.assign({}, dbTransfer, transfer)
+    const key = this.getTimestampedKey(combinedData)
     if (!key) {
       this.logger.warn('expected timestamped key. incomplete transfer:', JSON.stringify(transfer))
       return

--- a/packages/hop-node/src/db/TransfersDb.ts
+++ b/packages/hop-node/src/db/TransfersDb.ts
@@ -177,7 +177,7 @@ class TransfersDb extends BaseDb {
       return
     }
     const transferId = transfer.transferId
-    const dbTransfer = this.getById(transferId!)
+    const dbTransfer = await this.getById(transferId!)
     const combinedData = Object.assign({}, dbTransfer, transfer)
     const key = this.getTimestampedKey(combinedData)
     if (!key) {


### PR DESCRIPTION
@miguelmota Changes are what was discussed. I verified it works on the first write when `dbTransferRoot` will be `null`.