### PR TITLE
hop-node: Db: Clean up and simplify 

### DIFF
--- a/packages/hop-node/src/db/BaseDb.ts
+++ b/packages/hop-node/src/db/BaseDb.ts
@@ -121,6 +121,20 @@ class BaseDb extends EventEmitter {
       })
 
     this.pollBatchQueue()
+    this.migration()
+      .then(() => {
+        this.ready = true
+        this.logger.debug('ready')
+      })
+      .catch(err => {
+        this.logger.error(err)
+        process.exit(1)
+      })
+  }
+
+  async migration () {
+    // Optional migration,
+    // Implement in child class
   }
 
   protected async tilReady (): Promise<boolean> {
@@ -133,6 +147,7 @@ class BaseDb extends EventEmitter {
   }
 
   async pollBatchQueue () {
+    await this.tilReady()
     while (true) {
       try {
         await this.checkBatchQueue()

--- a/packages/hop-node/src/db/TransferRootsDb.ts
+++ b/packages/hop-node/src/db/TransferRootsDb.ts
@@ -5,13 +5,12 @@ import { Chain, ChallengePeriodMs, OneHourMs, OneWeekMs, RootSetSettleDelayMs, T
 import { normalizeDbItem } from './utils'
 import { oruChains } from 'src/config'
 
-export type TransferRoot = {
-  transferRootId?: string
+export interface BaseTransferRoot {
   transferRootHash?: string
   totalAmount?: BigNumber
   destinationChainId?: number
   sourceChainId?: number
-  sentCommitTxAt: number
+  sentCommitTxAt?: number
   committed?: boolean
   committedAt?: number
   commitTxHash?: string
@@ -37,6 +36,14 @@ export type TransferRoot = {
   multipleWithdrawalsSettledTxHash?: string
   multipleWithdrawalsSettledTotalAmount?: BigNumber
   isNotFound?: boolean
+}
+
+export interface TransferRoot extends BaseTransferRoot {
+  transferRootId: string
+}
+
+export interface UpdateTransferRoot extends BaseTransferRoot {
+  transferRootId?: string
 }
 
 type TransferRootsDateFilter = {
@@ -195,212 +202,106 @@ class TransferRootsDb extends BaseDb {
     this.subDbTimestamps = new BaseDb(`${prefix}:timestampedKeys`, _namespace)
     this.subDbIncompletes = new BaseDb(`${prefix}:incompleteItems`, _namespace)
     this.subDbRootHashes = new BaseDb(`${prefix}:rootHashes`, _namespace)
-
-    this.migration()
-      .then(() => {
-        this.ready = true
-        this.logger.debug('db ready')
-      })
-      .catch(err => {
-        this.logger.error(err)
-      })
+    this.ready = true
+    this.logger.debug('db ready')
   }
 
-  async migration () {
-    let items = await this.getKeyValues()
-    let promises: Array<Promise<any>> = []
-    for (const { key, value } of items) {
-      promises.push(new Promise(async (resolve) => {
-        const rootHashKv = await this.getRootHashKeyValueForUpdate(value)
-        if (rootHashKv) {
-          await this.subDbRootHashes._update(rootHashKv.key, rootHashKv.value)
-        }
-        resolve(null)
-      }))
-    }
-
-    await Promise.all(promises)
-
-    // re-index timestamped db keys by transfer root id
-    items = await this.subDbTimestamps.getKeyValues()
-    promises = []
-    for (const { key, value } of items) {
-      promises.push(new Promise(async (resolve) => {
-        if (!value?.transferRootHash) {
-          resolve(null)
-          return
-        }
-        const item = await this.getById(value.transferRootHash)
-        if (!item?.transferRootId) {
-          resolve(null)
-          return
-        }
-        const { transferRootId } = item
-        const parts = key.split(':')
-        if (parts.length < 2) {
-          resolve(null)
-          return
-        }
-        const newKey = `${parts[0]}:${parts[1]}:${transferRootId}`
-        await this.subDbTimestamps._update(newKey, { transferRootId })
-        await this.subDbTimestamps.deleteById(key)
-        resolve(null)
-      }))
-    }
-
-    await Promise.all(promises)
-
-    // re-index incomplete db item keys by transfer root id
-    items = await this.subDbIncompletes.getKeyValues()
-    promises = []
-    for (const { key, value } of items) {
-      promises.push(new Promise(async (resolve) => {
-        if (!value?.transferRootHash) {
-          resolve(null)
-          return
-        }
-        const item = await this.getById(value.transferRootHash)
-        if (!item?.transferRootId) {
-          resolve(null)
-          return
-        }
-        const { transferRootId } = item
-        await this.subDbIncompletes._update(transferRootId, { transferRootId })
-        await this.subDbIncompletes.deleteById(key)
-        resolve(null)
-      }))
-    }
-
-    await Promise.all(promises)
-
-    // re-index db keys by transfer root id
-    items = await this.getKeyValues()
-    promises = []
-    for (const { key, value } of items) {
-      promises.push(new Promise(async (resolve) => {
-        if (!value?.transferRootId || key === value?.transferRootId) {
-          resolve(null)
-          return
-        }
-        const { transferRootId } = value
-        await this._update(transferRootId, value)
-        await this.deleteById(key)
-        resolve(null)
-      }))
-    }
-
-    await Promise.all(promises)
+  private isInvalidOrNotFound (item: TransferRoot) {
+    const isNotFound = item?.isNotFound
+    const isInvalid = invalidTransferRoots[item.transferRootId]
+    return isNotFound || isInvalid // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing
   }
 
-  async updateIncompleteItem (item: Partial<TransferRoot>) {
-    if (!item) {
-      this.logger.error('expected item', item)
-      return
+  private isRouteOk (filter: GetItemsFilter = {}, item: TransferRoot) {
+    if (filter.sourceChainId) {
+      if (!item.sourceChainId || filter.sourceChainId !== item.sourceChainId) {
+        return false
+      }
     }
-    const { transferRootId } = item
-    if (!transferRootId) {
-      this.logger.error('expected transferRootId', item)
-      return
+
+    if (filter.destinationChainIds) {
+      if (!item.destinationChainId || !filter.destinationChainIds.includes(item.destinationChainId)) {
+        return false
+      }
     }
-    const isIncomplete = this.isItemIncomplete(item)
+
+    return true
+  }
+
+  private getTimestampedKey (transferRoot: TransferRoot) {
+    if (transferRoot.committedAt && transferRoot.transferRootId) {
+      return `transferRoot:${transferRoot.committedAt}:${transferRoot.transferRootId}`
+    }
+  }
+
+  private async upsertTimestampedKeyItem (transferRoot: TransferRoot) {
+    const { transferRootId } = transferRoot
+    const logger = this.logger.create({ id: transferRootId })
+    const key = this.getTimestampedKey(transferRoot)
+    if (key) {
+      const exists = await this.subDbTimestamps.getById(key)
+      if (!exists) {
+        logger.debug(`storing db transferRoot timestamped key item. key: ${key}`)
+        await this.subDbTimestamps._update(key, { transferRootId })
+        logger.debug(`updated db transferRoot timestamped key item. key: ${key}`)
+      }
+    }
+  }
+
+  private async upsertRootHashKeyItem (transferRoot: TransferRoot) {
+    const { transferRootId, transferRootHash } = transferRoot
+    const logger = this.logger.create({ id: transferRootId })
+    const key = transferRoot.transferRootHash
+    if (key) {
+      const exists = await this.subDbRootHashes.getById(key)
+      if (!exists) {
+        logger.debug(`storing db transferRoot rootHash key item. key: ${key}`)
+        await this.subDbRootHashes._update(key, { transferRootId })
+        logger.debug(`updated db transferRoot rootHash key item. key: ${key}`)
+      }
+    }
+  }
+
+  private async upsertTransferRootItem (transferRoot: TransferRoot) {
+    const { transferRootId } = transferRoot
+    const logger = this.logger.create({ id: transferRootId })
+    await this._update(transferRootId, transferRoot)
+    const entry = await this.getById(transferRootId)
+    logger.debug(`updated db transferRoot item. ${JSON.stringify(entry)}`)
+    await this.updateIncompleteItem(entry)
+  }
+
+  private async updateIncompleteItem (transferRoot: TransferRoot) {
+    const { transferRootId } = transferRoot
+    const logger = this.logger.create({ id: transferRootId })
+    const isIncomplete = this.isItemIncomplete(transferRoot)
     const exists = await this.subDbIncompletes.getById(transferRootId)
     const shouldUpsert = isIncomplete && !exists
     const shouldDelete = !isIncomplete && exists
+    logger.debug('storing db transferRoot incomplete key item')
     if (shouldUpsert) {
       await this.subDbIncompletes._update(transferRootId, { transferRootId })
     } else if (shouldDelete) {
       await this.subDbIncompletes.deleteById(transferRootId)
     }
+    logger.debug('updated db transferRoot incomplete key item')
   }
 
-  getTimestampedKey (transferRoot: Partial<TransferRoot>) {
-    if (transferRoot.committedAt && transferRoot.transferRootId) {
-      const key = `transferRoot:${transferRoot.committedAt}:${transferRoot.transferRootId}`
-      return key
-    }
+  private normalizeItem (item: TransferRoot) {
+    return normalizeDbItem(item)
   }
 
-  async getTimestampedKeyValueForUpdate (transferRoot: Partial<TransferRoot>) {
-    if (!transferRoot) {
-      this.logger.warn('expected transfer root object for timestamped key')
-      return
-    }
-    const transferRootId = transferRoot.transferRootId
-    const dbTransferRoot = await this.getById(transferRootId!)
-    const combinedData = Object.assign({}, dbTransferRoot, transferRoot)
-    const key = this.getTimestampedKey(combinedData)
-    if (!key) {
-      this.logger.warn('expected timestamped key. incomplete transfer root:', JSON.stringify(transferRoot))
-      return
-    }
-    if (!transferRootId) {
-      this.logger.warn(`expected transfer root id for timestamped key. key: ${key} incomplete transfer root: `, JSON.stringify(transferRoot))
-      return
-    }
-    const item = await this.subDbTimestamps.getById(key)
-    const exists = !!item
-    if (!exists) {
-      const value = { transferRootId }
-      return { key, value }
-    }
-  }
-
-  async getRootHashKeyValueForUpdate (transferRoot: Partial<TransferRoot>) {
-    if (!transferRoot) {
-      this.logger.warn('expected transfer root object for root hash key')
-      return
-    }
-    const transferRootId = transferRoot.transferRootId
-    const key = transferRoot.transferRootHash
-    if (!key) {
-      this.logger.warn('expected root hash key. incomplete transfer root:', JSON.stringify(transferRoot))
-      return
-    }
-    if (!transferRootId) {
-      this.logger.warn(`expected transfer root id for root hash key. key: ${key} incomplete transfer root: `, JSON.stringify(transferRoot))
-      return
-    }
-    const item = await this.subDbRootHashes.getById(key)
-    const exists = !!item
-    if (!exists) {
-      const value = { transferRootId }
-      return { key, value }
-    }
-  }
-
-  async update (transferRootId: string, transferRoot: Partial<TransferRoot>) {
+  async update (transferRootId: string, transferRoot: UpdateTransferRoot) {
     await this.tilReady()
     const logger = this.logger.create({ root: transferRootId })
     logger.debug('update called')
     transferRoot.transferRootId = transferRootId
-    const promises: Array<Promise<any>> = []
-    const timestampedKv = await this.getTimestampedKeyValueForUpdate(transferRoot)
-    if (timestampedKv) {
-      logger.debug(`storing timestamped key. key: ${timestampedKv.key} transferRootId: ${transferRootId}`)
-      promises.push(this.subDbTimestamps._update(timestampedKv.key, timestampedKv.value).then(() => {
-        logger.debug(`updated db item. key: ${timestampedKv.key}`)
-      }))
-    }
-    const rootHashKv = await this.getRootHashKeyValueForUpdate(transferRoot)
-    if (rootHashKv) {
-      logger.debug(`storing root hash key. key: ${rootHashKv.key} transferRootId: ${transferRootId}`)
-      promises.push(this.subDbRootHashes._update(rootHashKv.key, rootHashKv.value).then(() => {
-        logger.debug(`updated db item. key: ${rootHashKv.key}`)
-      }))
-    }
-    promises.push(this._update(transferRootId, transferRoot).then(async () => {
-      const entry = await this.getById(transferRootId)
-      logger.debug(`updated db transferRoot item. ${JSON.stringify(entry)}`)
-      await this.updateIncompleteItem(entry)
-    }))
-    await Promise.all(promises)
-  }
 
-  normalizeItem (item: Partial<TransferRoot>) {
-    if (!item) {
-      return item
-    }
-    return normalizeDbItem(item)
+    await Promise.all([
+      this.upsertTimestampedKeyItem(transferRoot as TransferRoot),
+      this.upsertRootHashKeyItem(transferRoot as TransferRoot),
+      this.upsertTransferRootItem(transferRoot as TransferRoot)
+    ])
   }
 
   async getByTransferRootId (
@@ -409,6 +310,14 @@ class TransferRootsDb extends BaseDb {
     await this.tilReady()
     const item: TransferRoot = await this.getById(transferRootId)
     return this.normalizeItem(item)
+  }
+
+  private readonly filterTimestampedKeyValues = (x: any) => {
+    return x?.value?.transferRootId
+  }
+
+  private readonly sortItems = (a: any, b: any) => {
+    return a?.committedAt - b?.committedAt
   }
 
   async getByTransferRootHash (
@@ -423,10 +332,6 @@ class TransferRootsDb extends BaseDb {
     return this.normalizeItem(item)
   }
 
-  private readonly filterTimestampedKeyValues = (x: any) => {
-    return x?.value?.transferRootId
-  }
-
   async getTransferRootIds (dateFilter?: TransferRootsDateFilter): Promise<string[]> {
     await this.tilReady()
     // return only transfer-root keys that are within specified range (filter by timestamped keys)
@@ -434,6 +339,7 @@ class TransferRootsDb extends BaseDb {
       gte: 'transferRoot:',
       lte: 'transferRoot:~'
     }
+
     if (dateFilter != null) {
       if (dateFilter.fromUnix) {
         filter.gte = `transferRoot:${dateFilter.fromUnix}`
@@ -442,12 +348,9 @@ class TransferRootsDb extends BaseDb {
         filter.lte = `transferRoot:${dateFilter.toUnix}~` // tilde is intentional
       }
     }
+
     const kv = await this.subDbTimestamps.getKeyValues(filter)
     return kv.map(this.filterTimestampedKeyValues).filter(this.filterExisty)
-  }
-
-  sortItems = (a: any, b: any) => {
-    return a?.committedAt - b?.committedAt
   }
 
   async getItems (dateFilter?: TransferRootsDateFilter): Promise<TransferRoot[]> {
@@ -455,9 +358,7 @@ class TransferRootsDb extends BaseDb {
     const transferRootIds = await this.getTransferRootIds(dateFilter)
     const batchedItems = await this.batchGetByIds(transferRootIds)
     const transferRoots = batchedItems.map(this.normalizeItem)
-
-    const items = transferRoots
-      .sort(this.sortItems)
+    const items = transferRoots.sort(this.sortItems)
 
     this.logger.debug(`items length: ${items.length}`)
     return items
@@ -465,14 +366,14 @@ class TransferRootsDb extends BaseDb {
 
   async getTransferRoots (dateFilter?: TransferRootsDateFilter): Promise<TransferRoot[]> {
     await this.tilReady()
-    return await this.getItems(dateFilter)
+    return this.getItems(dateFilter)
   }
 
   // gets only transfer roots within range: now - 2 weeks ago
   async getTransferRootsFromTwoWeeks (): Promise<TransferRoot[]> {
     await this.tilReady()
     const fromUnix = Math.floor((Date.now() - (OneWeekMs * 2)) / 1000)
-    return await this.getTransferRoots({
+    return this.getTransferRoots({
       fromUnix
     })
   }
@@ -665,11 +566,7 @@ class TransferRootsDb extends BaseDb {
     })
   }
 
-  isItemIncomplete (item: Partial<TransferRoot>) {
-    if (!item?.transferRootId) {
-      return false
-    }
-
+  isItemIncomplete (item: TransferRoot) {
     const shouldIgnoreItem = this.isInvalidOrNotFound(item)
     if (shouldIgnoreItem) {
       return false
@@ -690,7 +587,7 @@ class TransferRootsDb extends BaseDb {
   }
 
   async getIncompleteItems (
-    filter: Partial<TransferRoot> = {}
+    filter: GetItemsFilter = {}
   ) {
     await this.tilReady()
     const kv = await this.subDbIncompletes.getKeyValues()
@@ -715,28 +612,6 @@ class TransferRootsDb extends BaseDb {
 
       return this.isItemIncomplete(item)
     })
-  }
-
-  isInvalidOrNotFound (item: Partial<TransferRoot>) {
-    const isNotFound = item?.isNotFound
-    const isInvalid = invalidTransferRoots[item.transferRootId!]
-    return isNotFound || isInvalid // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing
-  }
-
-  isRouteOk (filter: GetItemsFilter = {}, item: Partial<TransferRoot>) {
-    if (filter.sourceChainId) {
-      if (!item.sourceChainId || filter.sourceChainId !== item.sourceChainId) {
-        return false
-      }
-    }
-
-    if (filter.destinationChainIds) {
-      if (!item.destinationChainId || !filter.destinationChainIds.includes(item.destinationChainId)) {
-        return false
-      }
-    }
-
-    return true
   }
 }
 

--- a/packages/hop-node/src/db/TransferRootsDb.ts
+++ b/packages/hop-node/src/db/TransferRootsDb.ts
@@ -5,7 +5,7 @@ import { Chain, ChallengePeriodMs, OneHourMs, OneWeekMs, RootSetSettleDelayMs, T
 import { normalizeDbItem } from './utils'
 import { oruChains } from 'src/config'
 
-export interface BaseTransferRoot {
+interface BaseTransferRoot {
   transferRootHash?: string
   totalAmount?: BigNumber
   destinationChainId?: number
@@ -42,7 +42,7 @@ export interface TransferRoot extends BaseTransferRoot {
   transferRootId: string
 }
 
-export interface UpdateTransferRoot extends BaseTransferRoot {
+interface UpdateTransferRoot extends BaseTransferRoot {
   transferRootId?: string
 }
 

--- a/packages/hop-node/src/db/TransfersDb.ts
+++ b/packages/hop-node/src/db/TransfersDb.ts
@@ -4,10 +4,9 @@ import { BigNumber } from 'ethers'
 import { OneWeekMs, TxError, TxRetryDelayMs } from 'src/constants'
 import { normalizeDbItem } from './utils'
 
-export type Transfer = {
+interface BaseTransfer {
   transferRootId?: string
   transferRootHash?: string
-  transferId?: string
   destinationChainId?: number
   destinationChainSlug?: string
   sourceChainId?: number
@@ -36,6 +35,14 @@ export type Transfer = {
   isBondable?: boolean
   committed?: boolean
   isNotFound?: boolean
+}
+
+export interface Transfer extends BaseTransfer {
+  transferId: string
+}
+
+interface UpdateTransfer extends BaseTransfer {
+  transferId?: string
 }
 
 type TransfersDateFilter = {
@@ -131,98 +138,45 @@ class TransfersDb extends BaseDb {
     this.subDbTimestamps = new BaseDb(`${prefix}:timestampedKeys`, _namespace)
     this.subDbIncompletes = new BaseDb(`${prefix}:incompleteItems`, _namespace)
     this.subDbRootHashes = new BaseDb(`${prefix}:transferRootHashes`, _namespace)
-
     this.ready = true
     this.logger.debug('db ready')
   }
 
-  async updateIncompleteItem (item: Partial<Transfer>) {
-    if (!item) {
-      this.logger.error('expected item', item)
-      return
-    }
-    const { transferId } = item
-    if (!transferId) {
-      this.logger.error('expected transferId', item)
-      return
-    }
-    const isIncomplete = this.isItemIncomplete(item)
-    const exists = await this.subDbIncompletes.getById(transferId)
-    const shouldUpsert = isIncomplete && !exists
-    const shouldDelete = !isIncomplete && exists
-    if (shouldUpsert) {
-      await this.subDbIncompletes._update(transferId, { transferId })
-    } else if (shouldDelete) {
-      await this.subDbIncompletes.deleteById(transferId)
-    }
-  }
-
-  getTimestampedKey (transfer: Partial<Transfer>) {
+  private getTimestampedKey (transfer: Transfer) {
     if (transfer.transferSentTimestamp && transfer.transferId) {
-      const key = `transfer:${transfer.transferSentTimestamp}:${transfer.transferId}`
-      return key
+      return `transfer:${transfer.transferSentTimestamp}:${transfer.transferId}`
     }
   }
 
-  getTransferRootHashKey (transfer: Partial<Transfer>) {
+  private getTransferRootHashKey (transfer: Transfer) {
     if (transfer.transferRootHash && transfer.transferId) {
-      const key = `${transfer.transferRootHash}:${transfer.transferId}`
-      return key
+      return `${transfer.transferRootHash}:${transfer.transferId}`
     }
   }
 
-  async getTimestampedKeyValueForUpdate (transfer: Partial<Transfer>) {
-    if (!transfer) {
-      this.logger.warn('expected transfer object for timestamped key')
-      return
-    }
-    const transferId = transfer.transferId
-    const dbTransfer = await this.getById(transferId!)
-    const combinedData = Object.assign({}, dbTransfer, transfer)
-    const key = this.getTimestampedKey(combinedData)
-    if (!key) {
-      this.logger.warn('expected timestamped key. incomplete transfer:', JSON.stringify(transfer))
-      return
-    }
-    if (!transferId) {
-      this.logger.warn(`expected transfer id for timestamped key. key: ${key} incomplete transfer: `, JSON.stringify(transfer))
-      return
-    }
-    const item = await this.subDbTimestamps.getById(key)
-    const exists = !!item
-    if (!exists) {
-      const value = { transferId }
-      return { key, value }
-    }
+  private isInvalidOrNotFound (item: Transfer) {
+    const isNotFound = item?.isNotFound
+    const isInvalid = invalidTransferIds[item.transferId]
+    return isNotFound || isInvalid // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing
   }
 
-  async update (transferId: string, transfer: Partial<Transfer>) {
-    const logger = this.logger.create({ id: transferId })
-    logger.debug('update called')
-    transfer.transferId = transferId
-    const timestampedKv = await this.getTimestampedKeyValueForUpdate(transfer)
-    const promises: Array<Promise<any>> = []
-    if (timestampedKv) {
-      logger.debug(`storing timestamped key. key: ${timestampedKv.key} transferId: ${transferId}`)
-      promises.push(this.subDbTimestamps._update(timestampedKv.key, timestampedKv.value).then(() => {
-        logger.debug(`updated db item. key: ${timestampedKv.key}`)
-      }))
-    }
-    if (transfer.transferRootHash) {
-      const key = this.getTransferRootHashKey(transfer)
-      if (key) {
-        promises.push(this.subDbRootHashes._update(key, { transferId }))
+  private isRouteOk (filter: GetItemsFilter = {}, item: Transfer) {
+    if (filter.sourceChainId) {
+      if (!item.sourceChainId || filter.sourceChainId !== item.sourceChainId) {
+        return false
       }
     }
-    promises.push(this._update(transferId, transfer).then(async () => {
-      const entry = await this.getById(transferId)
-      logger.debug(`updated db transfer item. ${JSON.stringify(entry)}`)
-      await this.updateIncompleteItem(entry)
-    }))
-    await Promise.all(promises)
+
+    if (filter.destinationChainIds) {
+      if (!item.destinationChainId || !filter.destinationChainIds.includes(item.destinationChainId)) {
+        return false
+      }
+    }
+
+    return true
   }
 
-  normalizeItem (item: Partial<Transfer>) {
+  private normalizeItem (item: Transfer) {
     if (!item) {
       return null
     }
@@ -241,13 +195,77 @@ class TransfersDb extends BaseDb {
     return normalizeDbItem(item)
   }
 
+  private readonly filterValueTransferId = (x: any) => {
+    return x?.value?.transferId
+  }
+
+  private async upsertTransferItem (transfer: Transfer) {
+    const { transferId } = transfer
+    const logger = this.logger.create({ id: transferId })
+    await this._update(transferId, transfer)
+    const entry = await this.getById(transferId)
+    logger.debug(`updated db transfer item. ${JSON.stringify(entry)}`)
+    await this.updateIncompleteItem(entry)
+  }
+
+  private async upsertTimestampedKeyItem (transfer: Transfer) {
+    const { transferId } = transfer
+    const logger = this.logger.create({ id: transferId })
+    const key = this.getTimestampedKey(transfer)
+    if (key) {
+      const exists = await this.subDbTimestamps.getById(key)
+      if (!exists) {
+        logger.debug(`storing db transfer timestamped key item. key: ${key} transferId: ${transferId}`)
+        await this.subDbTimestamps._update(key, { transferId })
+        logger.debug(`updated db transfer timestamped key item. key: ${key}`)
+      }
+    }
+  }
+
+  private async upsertRootHashKeyItem (transfer: Transfer) {
+    const { transferId } = transfer
+    const logger = this.logger.create({ id: transferId })
+    const key = this.getTransferRootHashKey(transfer)
+    if (key) {
+      const exists = await this.subDbRootHashes.getById(key)
+      if (!exists) {
+        logger.debug(`storing db transfer rootHash key item. key: ${key} transferId: ${transferId}`)
+        await this.subDbRootHashes._update(key, { transferId })
+        logger.debug(`updated db transfer rootHash key item. key: ${key}`)
+      }
+    }
+  }
+
+  private async updateIncompleteItem (transfer: Transfer) {
+    const { transferId } = transfer
+    const logger = this.logger.create({ id: transferId })
+    const isIncomplete = this.isItemIncomplete(transfer)
+    const exists = await this.subDbIncompletes.getById(transferId)
+    const shouldUpsert = isIncomplete && !exists
+    const shouldDelete = !isIncomplete && exists
+    logger.debug(`storing db transfer incomplete key item. transferId: ${transferId}`)
+    if (shouldUpsert) {
+      await this.subDbIncompletes._update(transferId, { transferId })
+    } else if (shouldDelete) {
+      await this.subDbIncompletes.deleteById(transferId)
+    }
+    logger.debug(`updated db transfer incomplete key item. transferId: ${transferId}`)
+  }
+
+  async update (transferId: string, transfer: UpdateTransfer) {
+    const logger = this.logger.create({ id: transferId })
+    logger.debug('update called')
+    transfer.transferId = transferId
+    await Promise.all([
+      this.upsertTimestampedKeyItem(transfer as Transfer),
+      this.upsertRootHashKeyItem(transfer as Transfer),
+      this.upsertTransferItem(transfer as Transfer)
+    ])
+  }
+
   async getByTransferId (transferId: string): Promise<Transfer> {
     const item: Transfer = await this.getById(transferId)
     return this.normalizeItem(item)
-  }
-
-  private readonly filterValueTransferId = (x: any) => {
-    return x?.value?.transferId
   }
 
   async getTransferIds (dateFilter?: TransfersDateFilter): Promise<string[]> {
@@ -270,6 +288,7 @@ class TransfersDb extends BaseDb {
     return kv.map(this.filterValueTransferId).filter(this.filterExisty)
   }
 
+  // sort explainer: https://stackoverflow.com/a/9175783/1439168
   sortItems = (a: any, b: any) => {
     /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
     if (a.transferSentBlockNumber! > b.transferSentBlockNumber!) return 1
@@ -282,15 +301,11 @@ class TransfersDb extends BaseDb {
 
   async getItems (dateFilter?: TransfersDateFilter): Promise<Transfer[]> {
     const transferIds = await this.getTransferIds(dateFilter)
-    this.logger.debug(`transferIds length: ${transferIds.length}`)
     const batchedItems = await this.batchGetByIds(transferIds)
     const transfers = batchedItems.map(this.normalizeItem)
-
-    // sort explainer: https://stackoverflow.com/a/9175783/1439168
-    const items = transfers
-      .sort(this.sortItems)
-
+    const items = transfers.sort(this.sortItems)
     this.logger.info(`items length: ${items.length}`)
+
     return items
   }
 
@@ -393,7 +408,7 @@ class TransfersDb extends BaseDb {
     })
   }
 
-  isItemIncomplete (item: Partial<Transfer>) {
+  isItemIncomplete (item: Transfer) {
     if (!item?.transferId) {
       return false
     }
@@ -439,28 +454,6 @@ class TransfersDb extends BaseDb {
 
       return this.isItemIncomplete(item)
     })
-  }
-
-  isInvalidOrNotFound (item: Partial<Transfer>) {
-    const isNotFound = item?.isNotFound
-    const isInvalid = invalidTransferIds[item.transferId!]
-    return isNotFound || isInvalid // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing
-  }
-
-  isRouteOk (filter: GetItemsFilter = {}, item: Partial<Transfer>) {
-    if (filter.sourceChainId) {
-      if (!item.sourceChainId || filter.sourceChainId !== item.sourceChainId) {
-        return false
-      }
-    }
-
-    if (filter.destinationChainIds) {
-      if (!item.destinationChainId || !filter.destinationChainIds.includes(item.destinationChainId)) {
-        return false
-      }
-    }
-
-    return true
   }
 }
 

--- a/packages/hop-node/src/watchers/BondTransferRootWatcher.ts
+++ b/packages/hop-node/src/watchers/BondTransferRootWatcher.ts
@@ -74,7 +74,7 @@ class BondTransferRootWatcher extends BaseWatcher {
       }
 
       promises.push(this.checkTransfersCommitted(
-        transferRootId!,
+        transferRootId,
         transferRootHash!,
         totalAmount!,
         destinationChainId!,

--- a/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
@@ -86,7 +86,7 @@ class BondWithdrawalWatcher extends BaseWatcher {
       }
 
       logger.debug('db poll completed')
-      promises.push(this.checkTransferId(transferId!).catch(err => {
+      promises.push(this.checkTransferId(transferId).catch(err => {
         this.logger.error('checkTransferId error:', err)
       }))
     }

--- a/packages/hop-node/src/watchers/ChallengeWatcher.ts
+++ b/packages/hop-node/src/watchers/ChallengeWatcher.ts
@@ -53,7 +53,7 @@ class ChallengeWatcher extends BaseWatcher {
 
     for (const dbTransferRoot of dbTransferRoots) {
       const { transferRootId } = dbTransferRoot
-      await this.checkChallengeableTransferRoot(transferRootId!)
+      await this.checkChallengeableTransferRoot(transferRootId)
     }
   }
 

--- a/packages/hop-node/src/watchers/SettleBondedWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/SettleBondedWithdrawalWatcher.ts
@@ -50,14 +50,14 @@ class SettleBondedWithdrawalWatcher extends BaseWatcher {
       const { transferRootId, transferIds } = dbTransferRoot
       // Mark a settlement as attempted here so that multiple db reads are not attempted every poll
       // This comes into play when a transfer is bonded after others in the same root have been settled
-      if (!this.settleAttemptedAt[transferRootId!]) {
-        this.settleAttemptedAt[transferRootId!] = 0
+      if (!this.settleAttemptedAt[transferRootId]) {
+        this.settleAttemptedAt[transferRootId] = 0
       }
-      const timestampOk = this.settleAttemptedAt[transferRootId!] + OneHourMs < Date.now()
+      const timestampOk = this.settleAttemptedAt[transferRootId] + OneHourMs < Date.now()
       if (!timestampOk) {
         continue
       }
-      this.settleAttemptedAt[transferRootId!] = Date.now()
+      this.settleAttemptedAt[transferRootId] = Date.now()
 
       // get all db transfer items that belong to root
       const dbTransfers: Transfer[] = []
@@ -84,7 +84,7 @@ class SettleBondedWithdrawalWatcher extends BaseWatcher {
 
       const allBondableTransfersSettled = this.syncWatcher.getIsDbTransfersAllSettled(dbTransfers)
       if (allBondableTransfersSettled) {
-        await this.db.transferRoots.update(transferRootId!, {
+        await this.db.transferRoots.update(transferRootId, {
           allSettled: true
         })
         continue
@@ -104,7 +104,7 @@ class SettleBondedWithdrawalWatcher extends BaseWatcher {
       for (const bonder of bonderSet.values()) {
         // check settle-able transfer root
         promises.push(
-          this.checkTransferRootId(transferRootId!, bonder)
+          this.checkTransferRootId(transferRootId, bonder)
             .catch((err: Error) => {
               this.logger.error('checkTransferRootId error:', err.message)
             })

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -157,7 +157,7 @@ class SyncWatcher extends BaseWatcher {
           await Promise.all(chunks.map(async (transferRoot: TransferRoot) => {
             const { transferRootId } = transferRoot
             this.logger.info(`populating transferRoot id: ${transferRootId}`)
-            return this.populateTransferRootDbItem(transferRootId!)
+            return this.populateTransferRootDbItem(transferRootId)
               .catch((err: Error) => {
                 this.logger.error('populateTransferRootDbItem error:', err)
                 this.notifier.error(`populateTransferRootDbItem error: ${err.message}`)
@@ -1176,11 +1176,11 @@ class SyncWatcher extends BaseWatcher {
     for (const transferRoot of transferRoots) {
       const { transferRootId } = transferRoot
       const l1Bridge = this.getSiblingWatcherByChainSlug(Chain.Ethereum).bridge as L1Bridge
-      const isBonded = await l1Bridge.isTransferRootIdBonded(transferRootId!)
+      const isBonded = await l1Bridge.isTransferRootIdBonded(transferRootId)
       if (isBonded) {
         const logger = this.logger.create({ root: transferRootId })
         logger.warn('calculateUnbondedTransferRootAmounts already bonded. isNotFound: true')
-        await this.db.transferRoots.update(transferRootId!, { isNotFound: true })
+        await this.db.transferRoots.update(transferRootId, { isNotFound: true })
         continue
       }
 

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -184,7 +184,7 @@ class SyncWatcher extends BaseWatcher {
           await Promise.all(chunks.map(async (transfer: Transfer) => {
             const { transferId } = transfer
             this.logger.info(`populating transferId: ${transferId}`)
-            return this.populateTransferDbItem(transferId!)
+            return this.populateTransferDbItem(transferId)
               .catch((err: Error) => {
                 this.logger.error('populateTransferDbItem error:', err)
                 this.notifier.error(`populateTransferDbItem error: ${err.message}`)
@@ -917,7 +917,7 @@ class SyncWatcher extends BaseWatcher {
     )
     const items = await this.db.transfers.getTransfersWithTransferRootHash(transferRootHash)
     if (items.length) {
-      const transferIds = items.map((item: Transfer) => item.transferId) as string[]
+      const transferIds = items.map((item: Transfer) => item.transferId)
       if (transferIds.length) {
         const tree = new MerkleTree(transferIds)
         const computedTransferRootHash = tree.getHexRoot()

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -156,10 +156,11 @@ class SyncWatcher extends BaseWatcher {
         for (const chunks of allChunks) {
           await Promise.all(chunks.map(async (transferRoot: TransferRoot) => {
             const { transferRootId } = transferRoot
-            this.logger.info(`populating transferRoot id: ${transferRootId}`)
+            const logger = this.logger.create({ id: transferRootId })
+            logger.debug(`populating transferRoot id: ${transferRootId}`)
             return this.populateTransferRootDbItem(transferRootId)
               .catch((err: Error) => {
-                this.logger.error('populateTransferRootDbItem error:', err)
+                logger.error('populateTransferRootDbItem error:', err)
                 this.notifier.error(`populateTransferRootDbItem error: ${err.message}`)
               })
           }))
@@ -183,10 +184,11 @@ class SyncWatcher extends BaseWatcher {
         for (const chunks of allChunks) {
           await Promise.all(chunks.map(async (transfer: Transfer) => {
             const { transferId } = transfer
-            this.logger.info(`populating transferId: ${transferId}`)
+            const logger = this.logger.create({ id: transferId })
+            logger.debug(`populating transferId: ${transferId}`)
             return this.populateTransferDbItem(transferId)
               .catch((err: Error) => {
-                this.logger.error('populateTransferDbItem error:', err)
+                logger.error('populateTransferDbItem error:', err)
                 this.notifier.error(`populateTransferDbItem error: ${err.message}`)
               })
           }))

--- a/packages/hop-node/src/watchers/xDomainMessageRelayWatcher.ts
+++ b/packages/hop-node/src/watchers/xDomainMessageRelayWatcher.ts
@@ -105,7 +105,7 @@ class xDomainMessageRelayWatcher extends BaseWatcher {
     )
     for (const { transferRootId } of dbTransferRoots) {
       // Parallelizing these calls produces RPC errors on Optimism
-      await this.checkTransfersCommitted(transferRootId!)
+      await this.checkTransfersCommitted(transferRootId)
     }
   }
 


### PR DESCRIPTION
- Makes `transferId` required in `TransfersDb`, with exception to `update` function which auto assigns it ([#344](https://github.com/hop-protocol/hop/issues/344))
- Makes `transferRootId` required in `TransferRootsDb`,  with exception to `update` function which auto assigns it ([#344](https://github.com/hop-protocol/hop/issues/344))
- Simplifies `subDbX` key update in `TransfersDb`; the `update` function is simpler now
- Simplifies `subDbX` key update in `TransferRootsDb`; the `update` function is simpler now
- Cleans up the false `expected timestamped key` logs
- Removes `migration` from `TransferRootsDb`