### PR TITLE
Feature/get all graph items

### DIFF
--- a/packages/hop-node/src/theGraph/getBondedWithdrawals.ts
+++ b/packages/hop-node/src/theGraph/getBondedWithdrawals.ts
@@ -34,7 +34,7 @@ export default async function getBondedWithdrawals (
     token,
     lastId
   })
-  let withdrawals  = jsonRes.withdrawalBondeds.map((x: any) => normalizeEntity(x))
+  let withdrawals = jsonRes.withdrawalBondeds.map((x: any) => normalizeEntity(x))
 
   lastId = withdrawals[withdrawals.length - 1].id
   const maxItemsLength = 1000

--- a/packages/hop-node/src/theGraph/getBondedWithdrawals.ts
+++ b/packages/hop-node/src/theGraph/getBondedWithdrawals.ts
@@ -36,9 +36,9 @@ export default async function getBondedWithdrawals (
   })
   let withdrawals = jsonRes.withdrawalBondeds.map((x: any) => normalizeEntity(x))
 
-  lastId = withdrawals[withdrawals.length - 1].id
   const maxItemsLength = 1000
   if (withdrawals.length === maxItemsLength) {
+    lastId = withdrawals[withdrawals.length - 1].id
     withdrawals = withdrawals.concat(await getBondedWithdrawals(
       chain,
       token,

--- a/packages/hop-node/src/theGraph/getBondedWithdrawals.ts
+++ b/packages/hop-node/src/theGraph/getBondedWithdrawals.ts
@@ -1,15 +1,20 @@
 import makeRequest from './makeRequest'
 import { normalizeEntity } from './shared'
 
-export default async function getBondedWithdrawals (chain: string, token: string) {
+export default async function getBondedWithdrawals (
+  chain: string,
+  token: string,
+  lastId: string = '0x0000000000000000000000000000000000000000'
+) {
   const query = `
-    query WithdrawalBondeds($token: String) {
+    query WithdrawalBonded($token: String, $lastId: ID) {
       withdrawalBondeds(
         where: {
-          token: $token
+          token: $token,
+          id_gt: $lastId
         },
-        orderBy: timestamp,
-        orderDirection: desc,
+        orderBy: id,
+        orderDirection: asc,
         first: 1000
       ) {
         id
@@ -26,7 +31,20 @@ export default async function getBondedWithdrawals (chain: string, token: string
     }
   `
   const jsonRes = await makeRequest(chain, query, {
-    token
+    token,
+    lastId
   })
-  return jsonRes.withdrawalBondeds.map((x: any) => normalizeEntity(x))
+  let withdrawals  = jsonRes.withdrawalBondeds.map((x: any) => normalizeEntity(x))
+
+  lastId = withdrawals[withdrawals.length - 1].id
+  const maxItemsLength = 1000
+  if (withdrawals.length === maxItemsLength) {
+    withdrawals = withdrawals.concat(await getBondedWithdrawals(
+      chain,
+      token,
+      lastId
+    ))
+  }
+
+  return withdrawals
 }

--- a/packages/hop-node/src/theGraph/getTransferIds.ts
+++ b/packages/hop-node/src/theGraph/getTransferIds.ts
@@ -20,7 +20,6 @@ export default async function getTransferIds (
         },
         orderBy: id,
         orderDirection: asc,
-        id_gt: $lastId,
         first: 1000,
       ) {
         id

--- a/packages/hop-node/src/theGraph/getTransferIds.ts
+++ b/packages/hop-node/src/theGraph/getTransferIds.ts
@@ -7,19 +7,20 @@ export default async function getTransferIds (
   chain: string,
   token: string,
   filters: Partial<Filters> = {},
-  skip: number = 0
+  lastId: string = '0x0000000000000000000000000000000000000000'
 ): Promise<any[]> {
   const query = `
-    query TransfersSent(${token ? '$token: String, ' : ''}$orderDirection: String, $startDate: Int, $endDate: Int, $skip: Int) {
+    query TransfersSent(${token ? '$token: String, ' : ''}$orderDirection: String, $startDate: Int, $endDate: Int, $lastId: ID) {
       transferSents(
         where: {
           ${token ? 'token: $token,' : ''}
           timestamp_gte: $startDate,
-          timestamp_lte: $endDate
+          timestamp_lte: $endDate,
+          id_gt: $lastId
         },
-        orderBy: blockNumber,
-        orderDirection: $orderDirection,
-        skip: $skip,
+        orderBy: id,
+        orderDirection: asc,
+        id_gt: $lastId,
         first: 1000,
       ) {
         id
@@ -46,8 +47,7 @@ export default async function getTransferIds (
     token,
     startDate: 0,
     endDate: MaxInt32,
-    orderDirection: 'desc',
-    skip
+    lastId
   }
   if (filters.startDate) {
     variables.startDate = DateTime.fromISO(filters.startDate).toSeconds() >>> 0
@@ -55,25 +55,18 @@ export default async function getTransferIds (
   if (filters.endDate) {
     variables.endDate = DateTime.fromISO(filters.endDate).toSeconds() >>> 0
   }
-  if (typeof filters.orderDesc === 'boolean') {
-    variables.orderDirection = filters.orderDesc ? 'desc' : 'asc'
-  }
   const jsonRes = await makeRequest(chain, query, variables)
   let transfers = jsonRes.transferSents.map((x: any) => normalizeEntity(x))
 
-  if (transfers.length === 1000) {
-    try {
-      transfers = transfers.concat(await getTransferIds(
-        chain,
-        token,
-        filters,
-        skip + 1000
-      ))
-    } catch (err) {
-      if (!err.message.includes('The `skip` argument must be between')) {
-        throw err
-      }
-    }
+  lastId = transfers[transfers.length - 1].id
+  const maxItemsLength = 1000
+  if (transfers.length === maxItemsLength) {
+    transfers = transfers.concat(await getTransferIds(
+      chain,
+      token,
+      filters,
+      lastId
+    ))
   }
 
   return transfers

--- a/packages/hop-node/src/theGraph/getTransferIds.ts
+++ b/packages/hop-node/src/theGraph/getTransferIds.ts
@@ -57,9 +57,9 @@ export default async function getTransferIds (
   const jsonRes = await makeRequest(chain, query, variables)
   let transfers = jsonRes.transferSents.map((x: any) => normalizeEntity(x))
 
-  lastId = transfers[transfers.length - 1].id
   const maxItemsLength = 1000
   if (transfers.length === maxItemsLength) {
+    lastId = transfers[transfers.length - 1].id
     transfers = transfers.concat(await getTransferIds(
       chain,
       token,

--- a/packages/hop-node/src/theGraph/getTransferRoots.ts
+++ b/packages/hop-node/src/theGraph/getTransferRoots.ts
@@ -1,16 +1,21 @@
 import makeRequest from './makeRequest'
 import { normalizeEntity } from './shared'
 
-export default async function getTransferRoots (chain: string, token: string, skip: number = 0): Promise<any[]> {
+export default async function getTransferRoots (
+  chain: string,
+  token: string,
+  lastId: string = '0x0000000000000000000000000000000000000000'
+): Promise<any[]> {
   const query = `
-    query TransferRoots($token: String, $skip: Int) {
+    query TransferRoots($token: String, $lastId: ID) {
       transfersCommitteds(
         where: {
-          token: $token
+          token: $token,
+          id_gt: $lastId
         },
-        orderBy: timestamp,
-        orderDirection: desc,
-        skip: $skip,
+        orderBy: id,
+        orderDirection: asc,
+        id_gt: $lastId,
         first: 1000
       ) {
         id
@@ -30,23 +35,19 @@ export default async function getTransferRoots (chain: string, token: string, sk
   `
   const jsonRes = await makeRequest(chain, query, {
     token,
-    skip
+    lastId
   })
 
   let roots = jsonRes.transfersCommitteds.map((x: any) => normalizeEntity(x))
 
-  if (roots.length === 1000) {
-    try {
-      roots = roots.concat(await getTransferRoots(
-        chain,
-        token,
-        skip + 1000
-      ))
-    } catch (err) {
-      if (!err.message.includes('The `skip` argument must be between')) {
-        throw err
-      }
-    }
+  lastId = roots[roots.length - 1].id
+  const maxItemsLength = 1000
+  if (roots.length === maxItemsLength) {
+    roots = roots.concat(await getTransferRoots(
+      chain,
+      token,
+      lastId
+    ))
   }
 
   return roots

--- a/packages/hop-node/src/theGraph/getTransferRoots.ts
+++ b/packages/hop-node/src/theGraph/getTransferRoots.ts
@@ -15,7 +15,6 @@ export default async function getTransferRoots (
         },
         orderBy: id,
         orderDirection: asc,
-        id_gt: $lastId,
         first: 1000
       ) {
         id

--- a/packages/hop-node/src/theGraph/getTransferRoots.ts
+++ b/packages/hop-node/src/theGraph/getTransferRoots.ts
@@ -39,9 +39,9 @@ export default async function getTransferRoots (
 
   let roots = jsonRes.transfersCommitteds.map((x: any) => normalizeEntity(x))
 
-  lastId = roots[roots.length - 1].id
   const maxItemsLength = 1000
   if (roots.length === maxItemsLength) {
+    lastId = roots[roots.length - 1].id
     roots = roots.concat(await getTransferRoots(
       chain,
       token,


### PR DESCRIPTION
Apparently TheGraph only allows for `skip`ping up to 6000 items.

* [Discord conversations](https://discord.com/channels/438038660412342282/438070183794573313/862337114019463199)
* Error message when we run large queries: `The skip argument must be between 0 and 5000, but is 6000`

The [docs](https://thegraph.com/docs/en/developer/graphql-api#pagination) mention "For retrieving a large number of items, it is much better to page through entities based on an attribute as shown in the last example.". Chris' recent TheGraph queries work this way as well. This PR attempts to do this by returning all items and using the ID as the index for the query and returning all IDs instead of being capped at 6000.

Only important note is that the order always needs to be `asc` for these searches, since it is "counting" up from `0x00000...` to `0xfffff` with this method.