### PR TITLE
Fix/xdai gasprice

### DIFF
--- a/packages/hop-node/src/constants/constants.ts
+++ b/packages/hop-node/src/constants/constants.ts
@@ -65,6 +65,7 @@ export const MaxGasPriceMultiplier = 1.25
 export const MinPriorityFeePerGas = 4
 export const PriorityFeePerGasCap = 20
 export const MinPolygonGasPrice = 30_000_000_000
+export const MaxGasPriceGweiXdai = 90
 
 export enum TokenIndex {
   CanonicalToken = 0,

--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -334,6 +334,11 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
   }
 
   getMaxGasPrice () {
+    // The xDai RPC endpoint sometimes returns bad data and should be capped lower.
+    if (this.chainSlug === Chain.xDai) {
+      const maxGasPriceGweiXdai = 90
+      return this.parseGwei(maxGasPriceGweiXdai)
+    }
     return this.parseGwei(this.maxGasPriceGwei)
   }
 
@@ -556,7 +561,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     const isMaxReached = gasFeeData.gasPrice?.gt(maxGasPrice) ?? gasFeeData.maxPriorityFeePerGas?.gt(priorityFeePerGasCap)
     if (isMaxReached) {
       if (!this.maxGasPriceReached) {
-        const warnMsg = `max gas price reached. boostedGasFee: (${this.getGasFeeDataAsString(gasFeeData)}, maxGasFee: (gasPrice: ${this.maxGasPriceGwei}, maxPriorityFeePerGas: ${this.priorityFeePerGasCap}). cannot boost`
+        const warnMsg = `max gas price reached. boostedGasFee: (${this.getGasFeeDataAsString(gasFeeData)}, maxGasFee: (gasPrice: ${maxGasPrice}, maxPriorityFeePerGas: ${priorityFeePerGasCap}). cannot boost`
         this.notifier.warn(warnMsg, { channel: gasBoostWarnSlackChannel })
         this.logger.warn(warnMsg)
         this.emit(State.MaxGasPriceReached, gasFeeData.gasPrice, this.boostIndex)

--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -9,7 +9,7 @@ import getProviderChainSlug from 'src/utils/getProviderChainSlug'
 import getTransferIdFromCalldata from 'src/utils/getTransferIdFromCalldata'
 import wait from 'src/utils/wait'
 import { BigNumber, Signer, providers } from 'ethers'
-import { Chain, MaxGasPriceMultiplier, MinPriorityFeePerGas, PriorityFeePerGasCap } from 'src/constants'
+import { Chain, MaxGasPriceGweiXdai, MaxGasPriceMultiplier, MinPriorityFeePerGas, PriorityFeePerGasCap } from 'src/constants'
 import { EventEmitter } from 'events'
 
 import { EstimateGasError, NonceTooLowError } from 'src/types/error'
@@ -336,8 +336,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
   getMaxGasPrice () {
     // The xDai RPC endpoint sometimes returns bad data and should be capped lower.
     if (this.chainSlug === Chain.xDai) {
-      const maxGasPriceGweiXdai = 90
-      return this.parseGwei(maxGasPriceGweiXdai)
+      return this.parseGwei(MaxGasPriceGweiXdai)
     }
     return this.parseGwei(this.maxGasPriceGwei)
   }

--- a/packages/hop-node/test/gasBoostSigner.test.ts
+++ b/packages/hop-node/test/gasBoostSigner.test.ts
@@ -5,8 +5,8 @@ import expectDefined from './utils/expectDefined'
 import getRpcProvider from 'src/utils/getRpcProvider'
 import wait from 'src/utils/wait'
 import { Wallet } from 'ethers'
-import { privateKey } from './config'
 import { parseUnits } from 'ethers/lib/utils'
+import { privateKey } from './config'
 
 describe('GasBoostSigner', () => {
   it('initialize', async () => {

--- a/packages/hop-node/test/gasBoostSigner.test.ts
+++ b/packages/hop-node/test/gasBoostSigner.test.ts
@@ -183,7 +183,7 @@ describe('GasBoostTransaction', () => {
     let gTx = new GasBoostTransaction(tx, signer, store)
 
     let maxGasPrice = gTx.getMaxGasPrice()
-    let expectedMaxGasPrice = parseUnits('100', 9)
+    let expectedMaxGasPrice = parseUnits('90', 9)
     expect(maxGasPrice).toEqual(expectedMaxGasPrice)
 
     const optimismProvider = getRpcProvider('optimism')

--- a/packages/hop-node/test/gasBoostSigner.test.ts
+++ b/packages/hop-node/test/gasBoostSigner.test.ts
@@ -6,6 +6,7 @@ import getRpcProvider from 'src/utils/getRpcProvider'
 import wait from 'src/utils/wait'
 import { Wallet } from 'ethers'
 import { privateKey } from './config'
+import { parseUnits } from 'ethers/lib/utils'
 
 describe('GasBoostSigner', () => {
   it('initialize', async () => {
@@ -173,5 +174,26 @@ describe('GasBoostTransaction', () => {
     }, signer, store)
 
     expect(gTx.id).toBeTruthy()
+  })
+  it('getMaxGasPrice', () => {
+    const tx = {
+      to: '0x81682250D4566B2986A2B33e23e7c52D401B7aB7',
+      value: '1'
+    }
+    let gTx = new GasBoostTransaction(tx, signer, store)
+
+    let maxGasPrice = gTx.getMaxGasPrice()
+    let expectedMaxGasPrice = parseUnits('100', 9)
+    expect(maxGasPrice).toEqual(expectedMaxGasPrice)
+
+    const optimismProvider = getRpcProvider('optimism')
+    expectDefined(optimismProvider)
+    const optimismSigner = new Wallet(privateKey, optimismProvider)
+
+    gTx = new GasBoostTransaction(tx, optimismSigner, store)
+
+    maxGasPrice = gTx.getMaxGasPrice()
+    expectedMaxGasPrice = parseUnits('500', 9)
+    expect(maxGasPrice).toEqual(expectedMaxGasPrice)
   })
 })


### PR DESCRIPTION
xDai has been returning very large `gasPrice` data [recently](https://blockscout.com/xdai/mainnet/tx/0xe113e7c90b0f854f9b435707cfa086b59fc2c5232877418a22cf5e672c3df8bc/logs) which causes us to hit our 500 Gwei cap. No other chain is exhibiting this behavior. These txs aren't getting boosted, they're just sent once.

The blocks are definitely not full, but there is weird behavior with other txs in the blocks -- some send 200+ Gwei while other send <5 gwei. I think this points to some weird data being returned form our RPC provider WRT how they aggregate gasPrice data.

This PR updates the `maxGasPrice` to a lower, reasonable number for xDai.