### PR TITLE
Fix/correct fee for htoken send

### DIFF
--- a/packages/hop-node/src/watchers/classes/L2Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/L2Bridge.ts
@@ -159,7 +159,8 @@ export default class L2Bridge extends Bridge {
     const amountOutMin = '0' // must be 0
     const destinationChain = this.chainIdToSlug(destinationChainId)
     const isNativeToken = this.tokenSymbol === 'MATIC' && this.chainSlug === Chain.Polygon
-    const { totalFee } = await bridge.getSendData(amount, this.chainSlug, destinationChain)
+    const isHTokenSend = true
+    const { totalFee } = await bridge.getSendData(amount, this.chainSlug, destinationChain, isHTokenSend)
 
     if (totalFee.gt(amount)) {
       throw new Error(`amount must be greater than bonder fee. Estimated bonder fee is ${this.formatUnits(totalFee)}`)

--- a/packages/sdk/src/HopBridge.ts
+++ b/packages/sdk/src/HopBridge.ts
@@ -515,11 +515,11 @@ class HopBridge extends Base {
       adjustedBonderFee = BigNumber.from(0)
       adjustedDestinationTxFee = BigNumber.from(0)
     } else if (isHTokenSend) {
-      // sending hTokens do not need to be adjusted for AMM swaps
+      // fees do not need to be adjusted for AMM slippage when sending hTokens
       adjustedBonderFee = bonderFeeRelative
       adjustedDestinationTxFee = destinationTxFee
     } else {
-      // adjusted fee is the fee in the canonical token after adjusting for the hToken price.
+      // adjusted fee is the fee in the canonical token after adjusting for the hToken price
       adjustedBonderFee = await this.calcFromHTokenAmount(
         bonderFeeRelative,
         destinationChain

--- a/packages/sdk/src/HopBridge.ts
+++ b/packages/sdk/src/HopBridge.ts
@@ -509,32 +509,30 @@ class HopBridge extends Base {
 
     let adjustedBonderFee
     let adjustedDestinationTxFee
-    const isSourceL1 = sourceChain.isL1
-    if (isSourceL1) {
+    let totalFee
+    if (sourceChain.isL1) {
       // there are no Hop fees when the source is L1
       adjustedBonderFee = BigNumber.from(0)
       adjustedDestinationTxFee = BigNumber.from(0)
-    } else if (isHTokenSend) {
-      // fees do not need to be adjusted for AMM slippage when sending hTokens
-      adjustedBonderFee = bonderFeeRelative
-      adjustedDestinationTxFee = destinationTxFee
-    } else {
-      // adjusted fee is the fee in the canonical token after adjusting for the hToken price
-      adjustedBonderFee = await this.calcFromHTokenAmount(
-        bonderFeeRelative,
-        destinationChain
-      )
-
-      adjustedDestinationTxFee = await this.calcFromHTokenAmount(
-        destinationTxFee,
-        destinationChain
-      )
-    }
-
-    let totalFee
-    if (isSourceL1) {
       totalFee = BigNumber.from(0)
     } else {
+      if (isHTokenSend) {
+        // fees do not need to be adjusted for AMM slippage when sending hTokens
+        adjustedBonderFee = bonderFeeRelative
+        adjustedDestinationTxFee = destinationTxFee
+      } else {
+        // adjusted fee is the fee in the canonical token after adjusting for the hToken price
+        adjustedBonderFee = await this.calcFromHTokenAmount(
+          bonderFeeRelative,
+          destinationChain
+        )
+
+        adjustedDestinationTxFee = await this.calcFromHTokenAmount(
+          destinationTxFee,
+          destinationChain
+        )
+      }
+
       // enforce bonderFeeAbsolute after adjustment
       const bonderFeeAbsolute = await this.getBonderFeeAbsolute()
       adjustedBonderFee = adjustedBonderFee.gt(bonderFeeAbsolute)


### PR DESCRIPTION
The SDK adjusts the bonder fee based on the AMM swap output even if the user is sending h tokens and not actually performing a swap. This PR fixes that by not adjusting the fees if the consumer of the SDK is simply sending hTokens.