### PR TITLE
hop-node: handle rpc errors when checking if recipient is receivable

### DIFF
--- a/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
@@ -371,7 +371,7 @@ class BondWithdrawalWatcher extends BaseWatcher {
       await destinationBridge.provider.call(tx)
       return true
     } catch (err) {
-      const revertErrMsgRegex = /(execution reverted)/i
+      const revertErrMsgRegex = /(execution reverted|VM execution error)/i
       const isRevertError = revertErrMsgRegex.test(err.message)
       if (isRevertError) {
         logger.error(`getIsRecipientReceivable err: ${err.message}`)

--- a/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
@@ -371,8 +371,14 @@ class BondWithdrawalWatcher extends BaseWatcher {
       await destinationBridge.provider.call(tx)
       return true
     } catch (err) {
-      logger.error(`getIsRecipientReceivable err: ${err.message}`)
-      return false
+      const revertErrMsgRegex = /(execution reverted)/i
+      const isRevertError = revertErrMsgRegex.test(err.message)
+      if (isRevertError) {
+        logger.error(`getIsRecipientReceivable err: ${err.message}`)
+        return false
+      }
+      logger.error(`getIsRecipientReceivable non-revert err: ${err.message}`)
+      return true
     }
   }
 }


### PR DESCRIPTION
Handles non-revert errors in `getIsRecipientReceivable()`.

Handles #336 