### PR TITLE
hop-node: Config: Read route bonder addresses from config file instead of core package. #329

### DIFF
--- a/packages/hop-node/src/cli/hopNode.ts
+++ b/packages/hop-node/src/cli/hopNode.ts
@@ -44,6 +44,7 @@ async function main (source: any) {
     throw new Error('config file is required')
   }
 
+  logger.warn(`dry mode: ${!!dryMode}`)
   if (s3Upload) {
     logger.info('s3 upload enabled')
   }
@@ -99,7 +100,9 @@ async function main (source: any) {
     logger.info(`${k} wait confirmations: ${waitConfirmations}`)
     logger.info(`${k} rpc: ${rpcUrl}`)
   }
-  logger.warn(`dry mode: ${dryMode}`)
+  if (globalConfig.bonders) {
+    logger.info(`config bonders: ${JSON.stringify(globalConfig.bonders)}`)
+  }
   const stateUpdateAddress = config?.stateUpdateAddress
   const { starts } = await startWatchers({
     enabledWatchers: Object.keys(config.watchers).filter(

--- a/packages/hop-node/src/config/config.ts
+++ b/packages/hop-node/src/config/config.ts
@@ -109,8 +109,8 @@ const normalizeNetwork = (network: string) => {
   return network
 }
 
-const getConfigByNetwork = (network: string): Pick<Config, 'network' | 'addresses' | 'networks' | 'bonders' | 'metadata' | 'isMainnet'> => {
-  const { addresses, networks, bonders, metadata } = isTestMode ? networkConfigs.test : (networkConfigs as any)?.[network]
+const getConfigByNetwork = (network: string): Pick<Config, 'network' | 'addresses' | 'networks' | 'metadata' | 'isMainnet'> => {
+  const { addresses, networks, metadata } = isTestMode ? networkConfigs.test : (networkConfigs as any)?.[network]
   network = normalizeNetwork(network)
   const isMainnet = network === Network.Mainnet
 
@@ -118,14 +118,13 @@ const getConfigByNetwork = (network: string): Pick<Config, 'network' | 'addresse
     network,
     addresses,
     networks,
-    bonders,
     metadata,
     isMainnet
   }
 }
 
 // get default config
-const { addresses, network, networks, metadata, bonders, isMainnet } = getConfigByNetwork(envNetwork)
+const { addresses, network, networks, metadata, isMainnet } = getConfigByNetwork(envNetwork)
 
 // defaults
 export const config: Config = {
@@ -136,7 +135,7 @@ export const config: Config = {
   tokens: {},
   bonderPrivateKey: bonderPrivateKey ?? '',
   metadata,
-  bonders,
+  bonders: {},
   stateUpdateAddress: '',
   fees: {},
   routes: {},
@@ -174,19 +173,31 @@ export const config: Config = {
 }
 
 export const setConfigByNetwork = (network: string) => {
-  const { addresses, networks, bonders, metadata, isMainnet } = getConfigByNetwork(network)
+  const { addresses, networks, metadata, isMainnet } = getConfigByNetwork(network)
   config.isMainnet = isMainnet
   config.addresses = addresses
   config.network = normalizeNetwork(network)
   config.networks = networks
-  config.bonders = bonders
   config.metadata = metadata
 }
 
 export const setConfigAddresses = (addresses: Addresses) => {
-  const { bridges, bonders } = addresses
+  const { bridges } = addresses
   config.addresses = bridges
+}
+
+export const setConfigBonders = (bonders: Bonders) => {
   config.bonders = bonders
+}
+
+export const getConfigBondersForToken = (token: string) => {
+  return (config.bonders as any)?.[token]
+}
+
+export const getConfigBonderForRoute = (token: string, sourceChain: string, destinationChain: string) => {
+  const bonders = getConfigBondersForToken(token)
+  const bonder = bonders?.[sourceChain]?.[destinationChain]
+  return bonder
 }
 
 export const setBonderPrivateKey = (privateKey: string) => {
@@ -266,6 +277,10 @@ export const setConfigTokens = (tokens: Tokens) => {
   config.tokens = { ...config.tokens, ...tokens }
 }
 
+export const getBonderConfig = (tokens: Tokens) => {
+  config.tokens = { ...config.tokens, ...tokens }
+}
+
 export const chainNativeTokens = ['ETH', 'MATIC', 'DAI']
 
 export enum Watchers {
@@ -277,5 +292,6 @@ export enum Watchers {
   xDomainMessageRelay = 'xDomainMessageRelay',
 }
 
+export { Bonders }
 export * from './validation'
 export * from './fileOps'

--- a/packages/hop-node/src/config/fileOps.ts
+++ b/packages/hop-node/src/config/fileOps.ts
@@ -2,13 +2,14 @@ import Logger, { setLogLevel } from 'src/logger'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { Chain } from 'src/constants'
 import {
-  CommitTransfersConfig,
-  Fees, Routes, Watchers, defaultConfigFilePath,
+  Bonders,
+  CommitTransfersConfig, Fees, Routes, Watchers,
+  defaultConfigFilePath,
   setBonderPrivateKey,
   setCommitTransfersConfig,
   setConfigAddresses,
+  setConfigBonders,
   setConfigByNetwork,
   setConfigTokens,
   setDbPath,
@@ -19,6 +20,7 @@ import {
   setStateUpdateAddress,
   setSyncConfig
 } from './config'
+import { Chain } from 'src/constants'
 import { getParameter } from 'src/aws/parameterStore'
 import { promptPassphrase } from 'src/prompt'
 import { recoverKeystore } from 'src/keystore'
@@ -94,6 +96,7 @@ export type FileConfig = {
   metrics?: MetricsConfig
   fees?: Fees
   routes: Routes
+  bonders?: Bonders
 }
 
 export async function setGlobalConfigFromConfigFile (
@@ -216,6 +219,10 @@ export async function setGlobalConfigFromConfigFile (
 
   if (config.commitTransfers != null) {
     setCommitTransfersConfig(config.commitTransfers)
+  }
+
+  if (config.bonders) {
+    setConfigBonders(config.bonders)
   }
 }
 

--- a/packages/hop-node/src/config/goerli.ts
+++ b/packages/hop-node/src/config/goerli.ts
@@ -3,8 +3,6 @@ import { goerli as goerliAddresses } from '@hop-protocol/core/addresses'
 import { goerli as metadata } from '@hop-protocol/core/metadata'
 
 const addresses = goerliAddresses.bridges
-const bonders = goerliAddresses.bonders
-
 const networks: any = {}
 
 for (const chain in _networks) {
@@ -18,4 +16,4 @@ for (const chain in _networks) {
   networks[chain].waitConfirmations = network?.waitConfirmations
 }
 
-export { addresses, networks, bonders, metadata }
+export { addresses, networks, metadata }

--- a/packages/hop-node/src/config/kovan.ts
+++ b/packages/hop-node/src/config/kovan.ts
@@ -3,8 +3,6 @@ import { kovan as kovanAddresses } from '@hop-protocol/core/addresses'
 import { kovan as metadata } from '@hop-protocol/core/metadata'
 
 const addresses = kovanAddresses.bridges
-const bonders = kovanAddresses.bonders
-
 const networks: any = {}
 
 for (const chain in _networks) {
@@ -18,4 +16,4 @@ for (const chain in _networks) {
   networks[chain].waitConfirmations = network?.waitConfirmations
 }
 
-export { addresses, networks, bonders, metadata }
+export { addresses, networks, metadata }

--- a/packages/hop-node/src/config/mainnet.ts
+++ b/packages/hop-node/src/config/mainnet.ts
@@ -3,8 +3,6 @@ import { mainnet as mainnetAddresses } from '@hop-protocol/core/addresses'
 import { mainnet as metadata } from '@hop-protocol/core/metadata'
 
 const addresses = mainnetAddresses.bridges
-const bonders = mainnetAddresses.bonders
-
 const networks: any = {}
 
 for (const chain in _networks) {
@@ -18,4 +16,4 @@ for (const chain in _networks) {
   networks[chain].waitConfirmations = network?.waitConfirmations
 }
 
-export { addresses, networks, bonders, metadata }
+export { addresses, networks, metadata }

--- a/packages/hop-node/src/config/staging.ts
+++ b/packages/hop-node/src/config/staging.ts
@@ -3,8 +3,6 @@ import { mainnet as metadata } from '@hop-protocol/core/metadata'
 import { staging as stagingAddresses } from '@hop-protocol/core/addresses'
 
 const addresses = stagingAddresses.bridges
-const bonders = stagingAddresses.bonders
-
 const networks: any = {}
 
 for (const chain in _networks) {
@@ -18,4 +16,4 @@ for (const chain in _networks) {
   networks[chain].waitConfirmations = network?.waitConfirmations
 }
 
-export { addresses, networks, bonders, metadata }
+export { addresses, networks, metadata }

--- a/packages/hop-node/src/config/validation.ts
+++ b/packages/hop-node/src/config/validation.ts
@@ -45,7 +45,8 @@ export async function validateConfigFileStructure (config?: FileConfig) {
     'stateUpdateAddress',
     'metrics',
     'fees',
-    'routes'
+    'routes',
+    'bonders'
   ]
 
   const validWatcherKeys = [

--- a/packages/hop-node/src/watchers/ContractStateWatcher.ts
+++ b/packages/hop-node/src/watchers/ContractStateWatcher.ts
@@ -6,7 +6,7 @@ import swapAbi from '@hop-protocol/core/abi/generated/Swap.json'
 import wallets from 'src/wallets'
 import { Chain } from 'src/constants'
 import { Contract } from 'ethers'
-import { getEnabledNetworks, config as globalConfig } from 'src/config'
+import { getConfigBondersForToken, getEnabledNetworks, config as globalConfig } from 'src/config'
 
 type Config = {
   token: string
@@ -90,7 +90,7 @@ class ContractStateWatcher {
   private async getBonderStates (bridge: any) {
     const bonderStates: any = {}
     const bonders = new Set<string>()
-    const tokenBonderRoutes = (globalConfig.bonders as any)?.[this.token]
+    const tokenBonderRoutes = getConfigBondersForToken(this.token)
     for (const sourceChain in tokenBonderRoutes) {
       for (const destinationChain in tokenBonderRoutes?.[sourceChain]) {
         const bonder = tokenBonderRoutes?.[sourceChain]?.[destinationChain]

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -751,8 +751,4 @@ export default class Bridge extends ContractBase {
 
     return 'ETH'
   }
-
-  getConfigBonderAddress (destinationChain: string): string {
-    return (globalConfig?.bonders as any)?.[this.tokenSymbol]?.[this.chainSlug]?.[destinationChain]
-  }
 }

--- a/packages/hop-node/src/watchers/watchers.ts
+++ b/packages/hop-node/src/watchers/watchers.ts
@@ -12,7 +12,7 @@ import contracts from 'src/contracts'
 import xDomainMessageRelayWatcher from 'src/watchers/xDomainMessageRelayWatcher'
 import { Chain } from 'src/constants'
 import { MetricsServer } from 'src/metrics'
-import { Watchers, config as globalConfig, getAllTokens, getAllChains } from 'src/config'
+import { Watchers, getAllChains, getAllTokens, config as globalConfig } from 'src/config'
 
 const logger = new Logger('config')
 
@@ -324,4 +324,3 @@ export function findWatcher (watchers: Watcher[], WatcherType: any, chain?: stri
     return watcher
   })
 }
-


### PR DESCRIPTION
- Removes reliance on bonder addresses from `core` package
- Adds option to use `bonders` from config file 