### PR TITLE
Feat/add reencrypt keystore

### DIFF
--- a/packages/hop-node/src/cli/keystores.ts
+++ b/packages/hop-node/src/cli/keystores.ts
@@ -31,12 +31,7 @@ root
 async function main (source: any) {
   let { override, args, pass: passphrase, path: keystoreFilePath, privateKey } = source
   const action = args[0]
-  const actionOptions = [
-    Actions.Generate,
-    Actions.Decrypt,
-    Actions.Reencrypt,
-    Actions.Address
-  ]
+  const actionOptions = Object.values(Actions)
 
   if (!action) {
     throw new Error('please specify subcommand')
@@ -153,30 +148,21 @@ Press [Enter] to exit.
     if (!passphrase) {
       passphrase = await promptPassphrase()
     }
-
     const oldPassphrase = passphrase
-    const newPassphrase = await generatePassphrase()
-
     let keystore = getKeystore(keystoreFilePath)
     const recoveredPrivateKey = await recoverKeystore(keystore, oldPassphrase)
+
+    const newPassphrase = await generatePassphrase()
     keystore = await generateKeystore(recoveredPrivateKey, newPassphrase)
     fs.writeFileSync(keystoreFilePath, JSON.stringify(keystore), 'utf8')
-
-    await prompt.get({
-      properties: {
-        blank: {
-          message: `
+    console.log(`
 ㅤ${hopArt}
 Public address: 0x${keystore.address}
 Your keys can be found at: ${keystoreFilePath}
 
 Keystore reencryption is complete.
-Press [Enter] to exit.
 `
-        }
-      }
-    } as any)
-    clearConsole()
+    )
   } else if (action === Actions.Address) {
     const keystore = getKeystore(keystoreFilePath)
     const address = keystore.address

--- a/packages/hop-node/src/cli/keystores.ts
+++ b/packages/hop-node/src/cli/keystores.ts
@@ -12,31 +12,46 @@ import { hopArt } from './shared/art'
 import { prompt, promptPassphrase } from 'src/prompt'
 import { randomBytes } from 'crypto'
 
+enum Actions {
+  Generate = 'generate',
+  Decrypt = 'decrypt',
+  Reencrypt = 'reencrypt',
+  Address = 'address'
+}
+
 root
   .command('keystore')
   .description('Keystore')
   .option('--pass <secret>', 'Passphrase to encrypt keystore with.', parseString)
-  .option('-o, --output <path>', 'Output file path of encrypted keystore.', parseString)
+  .option('--path <path>', 'File path of encrypted keystore.', parseString)
   .option('--override [boolean]', 'Override existing keystore if it exists.', parseBool)
   .option('--private-key <private-key>', 'The private key to encrypt.', parseString)
   .action(actionHandler(main))
 
 async function main (source: any) {
-  let { config, override, args, pass: passphrase, output, privateKey } = source
+  let { override, args, pass: passphrase, path: keystoreFilePath, privateKey } = source
   const action = args[0]
-  output = output || defaultKeystoreFilePath
+  const actionOptions = [
+    Actions.Generate,
+    Actions.Decrypt,
+    Actions.Reencrypt,
+    Actions.Address
+  ]
+
   if (!action) {
     throw new Error('please specify subcommand')
   }
-  if (action === 'generate') {
+  if (!actionOptions.includes(action)) {
+    throw new Error(`Please choose a valid option. Valid options include ${actionOptions}.`)
+  }
+  keystoreFilePath = keystoreFilePath || defaultKeystoreFilePath
+  if (!keystoreFilePath) {
+    throw new Error('please specify keystore filepath')
+  }
+
+  if (action === Actions.Generate) {
     if (!passphrase) {
-      passphrase = await promptPassphrase(
-        'Enter new keystore encryption password'
-      )
-      const passphraseConfirm = await promptPassphrase('Confirm password')
-      if (passphrase !== passphraseConfirm) {
-        throw new Error('ERROR: passwords did not match')
-      }
+      passphrase = await generatePassphrase()
     }
     let mnemonic: string | undefined
     const hdpath = 'm/44\'/60\'/0\'/0/0'
@@ -99,7 +114,7 @@ Press [Enter] to try again.`
     }
 
     const keystore = await generateKeystore(privateKey, passphrase)
-    const filepath = path.resolve(output)
+    const filepath = path.resolve(keystoreFilePath)
     const exists = fs.existsSync(filepath)
     if (exists) {
       if (!override) {
@@ -127,30 +142,66 @@ Press [Enter] to exit.
       }
     } as any)
     clearConsole()
-  } else if (action === 'decrypt') {
+  } else if (action === Actions.Decrypt) {
     if (!passphrase) {
       passphrase = await promptPassphrase()
     }
-    const filepath = source.args[1] || defaultKeystoreFilePath
-    if (!filepath) {
-      throw new Error('please specify filepath')
+    const keystore = getKeystore(keystoreFilePath)
+    const recoveredPrivateKey = await recoverKeystore(keystore, passphrase)
+    console.log(recoveredPrivateKey) // intentional log
+  } else if (action === Actions.Reencrypt) {
+    if (!passphrase) {
+      passphrase = await promptPassphrase()
     }
-    const keystore = JSON.parse(
-      fs.readFileSync(path.resolve(filepath), 'utf8')
-    )
-    const privateKey = await recoverKeystore(keystore, passphrase)
-    console.log(privateKey) // intentional log
-  } else if (action === 'address') {
-    const filepath = source.args[1] || defaultKeystoreFilePath
-    if (!filepath) {
-      throw new Error('please specify filepath')
-    }
-    const keystore = JSON.parse(
-      fs.readFileSync(path.resolve(filepath), 'utf8')
-    )
+
+    const oldPassphrase = passphrase
+    const newPassphrase = await generatePassphrase()
+
+    let keystore = getKeystore(keystoreFilePath)
+    const recoveredPrivateKey = await recoverKeystore(keystore, oldPassphrase)
+    keystore = await generateKeystore(recoveredPrivateKey, newPassphrase)
+    fs.writeFileSync(keystoreFilePath, JSON.stringify(keystore), 'utf8')
+
+    await prompt.get({
+      properties: {
+        blank: {
+          message: `
+ㅤ${hopArt}
+Public address: 0x${keystore.address}
+Your keys can be found at: ${keystoreFilePath}
+
+Keystore reencryption is complete.
+Press [Enter] to exit.
+`
+        }
+      }
+    } as any)
+    clearConsole()
+  } else if (action === Actions.Address) {
+    const keystore = getKeystore(keystoreFilePath)
     const address = keystore.address
     console.log(`0x${address}`) // intentional log
-  } else {
-    console.log(`unsupported command: "${action}"`) // intentional log
+  }
+}
+
+async function generatePassphrase(): Promise<string> {
+  const passphrase = await promptPassphrase(
+    'Enter new keystore encryption passphrase'
+  )
+  const passphraseConfirm = await promptPassphrase('Confirm passphrase')
+  if (passphrase !== passphraseConfirm) {
+    throw new Error('ERROR: passphrases did not match')
+  }
+
+  return (passphrase as string)
+}
+
+function getKeystore(filepath: string): any{
+  try {
+    return JSON.parse(
+      fs.readFileSync(path.resolve(filepath), 'utf8')
+    )
+  } catch (err) {
+    throw new Error(`keystore does not exist at ${filepath}`)
   }
 }


### PR DESCRIPTION
* Add ability to `reencrypt` keystores
* Only major change is that a custom file path needs to be explicitly passed in with `—path` instead of `args[1]`. I did this because I didn’t think it was possible for a user to know that `args[1]` should be the path, but happy to revert to what it was if you think otherwise.
* DRYed some logic that is now re-used b/c of new command