### PR TITLE
fix errors when routing w/ unsupported url params

### DIFF
--- a/packages/frontend/src/components/TokenWrapper/TokenWrapperContext.tsx
+++ b/packages/frontend/src/components/TokenWrapper/TokenWrapperContext.tsx
@@ -17,11 +17,11 @@ type TokenWrapperContextProps = {
   unwrap: () => void
   isWrapping: boolean
   isUnwrapping: boolean
-  selectedNetwork: Network | undefined
+  selectedNetwork?: Network
   setSelectedNetwork: (network: Network) => void
-  canonicalToken: Token | undefined
+  canonicalToken?: Token
   canonicalTokenBalance: BigNumber | undefined
-  wrappedToken: Token | undefined
+  wrappedToken?: Token
   wrappedTokenBalance: BigNumber | undefined
   error: string | null | undefined
   setError: (error: string | null | undefined) => void
@@ -53,9 +53,11 @@ const TokenWrapperContextProvider: FC = ({ children }) => {
   const l2Networks = useMemo(() => {
     return networks.filter(network => !network.isLayer1)
   }, [networks])
-  const [selectedNetwork, setSelectedNetwork] = useState<Network>(l2Networks[0])
+  const [selectedNetwork, setSelectedNetwork] = useState<Network>()
   const canonicalToken = useMemo(() => {
-    return selectedBridge?.getCanonicalToken(selectedNetwork.slug)
+    if (selectedNetwork) {
+      return selectedBridge?.getCanonicalToken(selectedNetwork?.slug)
+    }
   }, [selectedBridge, selectedNetwork])
   const wrappedToken = useMemo(() => {
     return canonicalToken?.getWrappedToken()
@@ -101,7 +103,7 @@ const TokenWrapperContextProvider: FC = ({ children }) => {
 
   const wrap = async () => {
     try {
-      const networkId = Number(selectedNetwork.networkId)
+      const networkId = Number(selectedNetwork?.networkId)
       const isNetworkConnected = await checkConnectedNetworkId(networkId)
       if (!isNetworkConnected) return
 
@@ -146,7 +148,7 @@ const TokenWrapperContextProvider: FC = ({ children }) => {
           })
         )
 
-        await waitForTransaction(tokenWrapTx, { networkName: selectedNetwork.slug })
+        await waitForTransaction(tokenWrapTx, { networkName: selectedNetwork?.slug })
       }
     } catch (err: any) {
       if (!/cancelled/gi.test(err.message)) {
@@ -158,7 +160,7 @@ const TokenWrapperContextProvider: FC = ({ children }) => {
 
   const unwrap = async () => {
     try {
-      const networkId = Number(selectedNetwork.networkId)
+      const networkId = Number(selectedNetwork?.networkId)
       const isNetworkConnected = await checkConnectedNetworkId(networkId)
       if (!isNetworkConnected) return
 
@@ -196,11 +198,11 @@ const TokenWrapperContextProvider: FC = ({ children }) => {
         addTransaction(
           new Transaction({
             hash: tokenUnwrapTx.hash,
-            networkName: selectedNetwork.slug,
+            networkName: selectedNetwork?.slug,
           })
         )
 
-        await waitForTransaction(tokenUnwrapTx, { networkName: selectedNetwork.slug })
+        await waitForTransaction(tokenUnwrapTx, { networkName: selectedNetwork?.slug })
       }
     } catch (err: any) {
       if (!/cancelled/gi.test(err.message)) {

--- a/packages/frontend/src/contexts/AppContext/useNetworks.ts
+++ b/packages/frontend/src/contexts/AppContext/useNetworks.ts
@@ -34,7 +34,7 @@ const useNetworks = () => {
   return {
     networks: allNetworks,
     l2Networks,
-    defaultL2Network: l2Networks[0],
+    defaultL2Network: l2Networks[2],
   }
 }
 

--- a/packages/frontend/src/contexts/Web3Context.tsx
+++ b/packages/frontend/src/contexts/Web3Context.tsx
@@ -278,7 +278,8 @@ const Web3ContextProvider: FC = ({ children }) => {
   const walletConnected = !!address
 
   // TODO: cleanup
-  const checkConnectedNetworkId = async (networkId: number): Promise<boolean> => {
+  const checkConnectedNetworkId = async (networkId?: number): Promise<boolean> => {
+    if (!networkId) return false
     const signerNetworkId = (await provider?.getNetwork())?.chainId
     logger.debug('checkConnectedNetworkId', networkId, signerNetworkId)
     if (networkId.toString() !== signerNetworkId?.toString()) {

--- a/packages/frontend/src/hooks/useAssets.ts
+++ b/packages/frontend/src/hooks/useAssets.ts
@@ -36,22 +36,22 @@ export function useAssets(selectedBridge?: HopBridge, fromNetwork?: Network, toN
   // Set source token
   const sourceToken = useMemo(() => {
     try {
-      if (!fromNetwork || !selectedBridge) return
+      if (!fromNetwork || !selectedBridge || unsupportedAsset?.chain) return
       return selectedBridge.getCanonicalToken(fromNetwork?.slug)
     } catch (err) {
       logger.error(err)
     }
-  }, [selectedBridge, fromNetwork])
+  }, [unsupportedAsset, selectedBridge, fromNetwork])
 
   // Set destination token
   const destToken = useMemo(() => {
     try {
-      if (!toNetwork || !selectedBridge) return
+      if (!toNetwork || !selectedBridge || unsupportedAsset?.chain) return
       return selectedBridge.getCanonicalToken(toNetwork?.slug)
     } catch (err) {
       logger.error(err)
     }
-  }, [selectedBridge, toNetwork])
+  }, [unsupportedAsset, selectedBridge, toNetwork])
 
   // Set placeholder token
   const placeholderToken = useMemo(() => {

--- a/packages/frontend/src/pages/Pools/PoolsContext.tsx
+++ b/packages/frontend/src/pages/Pools/PoolsContext.tsx
@@ -26,11 +26,11 @@ import { useInterval } from 'react-use'
 
 type PoolsContextProps = {
   networks: Network[]
-  canonicalToken: Token | undefined
-  hopToken: Token | undefined
-  address: Address | undefined
+  canonicalToken?: Token
+  hopToken?: Token
+  address?: Address
   totalSupply: string | undefined
-  selectedNetwork: Network | undefined
+  selectedNetwork?: Network
   setSelectedNetwork: (network: Network) => void
   token0Amount: string
   setToken0Amount: (value: string) => void
@@ -59,9 +59,9 @@ type PoolsContextProps = {
   validFormFields: boolean
   sendButtonText: string
   error: string | null | undefined
-  warning: string | undefined
+  warning?: string
   setError: (error: string | null | undefined) => void
-  setWarning: (warning: string | undefined) => void
+  setWarning: (warning?: string) => void
   isNativeToken: boolean
   fee: number | undefined
   apr: number | undefined
@@ -110,7 +110,7 @@ const PoolsContext = createContext<PoolsContextProps>({
   error: null,
   warning: undefined,
   setError: (error: string | null | undefined) => {},
-  setWarning: (warning: string | undefined) => {},
+  setWarning: (warning?: string) => {},
   isNativeToken: false,
   fee: undefined,
   apr: undefined,
@@ -152,53 +152,7 @@ const PoolsContextProvider: FC = ({ children }) => {
   const l2Networks = useMemo(() => {
     return networks.filter(network => !network.isLayer1)
   }, [networks])
-  const [selectedNetwork, setSelectedNetwork] = useState<Network>(l2Networks[0])
-  const isNativeToken =
-    useMemo(() => {
-      try {
-        const token = selectedBridge?.getCanonicalToken(selectedNetwork.slug)
-        return token?.isNativeToken
-      } catch (err) {
-        logger.error(err)
-      }
-      return false
-    }, [selectedBridge, selectedNetwork]) ?? false
-
-  const canonicalToken = useMemo(() => {
-    try {
-      const token = selectedBridge?.getCanonicalToken(selectedNetwork.slug)
-      if (token?.isNativeToken) {
-        return token?.getWrappedToken()
-      }
-      return token
-    } catch (err) {
-      logger.error(err)
-    }
-  }, [selectedBridge, selectedNetwork])
-
-  const hopToken = useMemo(() => {
-    try {
-      return selectedBridge?.getL2HopToken(selectedNetwork.slug)
-    } catch (err) {
-      logger.error(err)
-    }
-  }, [selectedBridge, selectedNetwork])
-
-  const [txHash, setTxHash] = useState<string | undefined>()
-  const [sending, setSending] = useState<boolean>(false)
-  const [removing, setRemoving] = useState<boolean>(false)
-
-  const { balance: canonicalBalance, loading: loadingCanonicalBalance } = useBalance(
-    canonicalToken,
-    selectedNetwork,
-    address
-  )
-
-  const { balance: hopBalance, loading: loadingHopBalance } = useBalance(
-    hopToken,
-    selectedNetwork,
-    address
-  )
+  const [selectedNetwork, setSelectedNetwork] = useState<Network>(l2Networks[2])
 
   const unsupportedAsset = useMemo(() => {
     if (!(selectedBridge && selectedNetwork)) {
@@ -227,6 +181,57 @@ const PoolsContextProvider: FC = ({ children }) => {
     return null
   }, [selectedBridge, selectedNetwork])
 
+
+  const isNativeToken =
+    useMemo(() => {
+      try {
+        if (!selectedNetwork || unsupportedAsset?.chain) return false
+        const token = selectedBridge?.getCanonicalToken(selectedNetwork.slug)
+        return token?.isNativeToken
+      } catch (err) {
+        logger.error(err)
+      }
+      return false
+    }, [unsupportedAsset, selectedBridge, selectedNetwork]) ?? false
+
+  const canonicalToken = useMemo(() => {
+    try {
+      if (!selectedNetwork || unsupportedAsset?.chain) return
+      const token = selectedBridge?.getCanonicalToken(selectedNetwork.slug)
+      if (token?.isNativeToken) {
+        return token?.getWrappedToken()
+      }
+      return token
+    } catch (err) {
+      logger.error(err)
+    }
+  }, [unsupportedAsset, selectedBridge, selectedNetwork])
+
+  const hopToken = useMemo(() => {
+    try {
+      if (!selectedNetwork || unsupportedAsset?.chain) return
+      return selectedBridge?.getL2HopToken(selectedNetwork.slug)
+    } catch (err) {
+      logger.error(err)
+    }
+  }, [unsupportedAsset, selectedBridge, selectedNetwork])
+
+  const [txHash, setTxHash] = useState<string | undefined>()
+  const [sending, setSending] = useState<boolean>(false)
+  const [removing, setRemoving] = useState<boolean>(false)
+
+  const { balance: canonicalBalance, loading: loadingCanonicalBalance } = useBalance(
+    canonicalToken,
+    selectedNetwork,
+    address
+  )
+
+  const { balance: hopBalance, loading: loadingHopBalance } = useBalance(
+    hopToken,
+    selectedNetwork,
+    address
+  )
+
   useEffect(() => {
     if (unsupportedAsset) {
       const { chain, tokenSymbol } = unsupportedAsset
@@ -238,7 +243,7 @@ const PoolsContextProvider: FC = ({ children }) => {
 
   const tokenUsdPrice = useAsyncMemo(async () => {
     try {
-      if (!canonicalToken) {
+      if (!canonicalToken || unsupportedAsset?.chain) {
         return
       }
       const bridge = await sdk.bridge(canonicalToken.symbol)
@@ -247,14 +252,14 @@ const PoolsContextProvider: FC = ({ children }) => {
     } catch (err) {
       console.error(err)
     }
-  }, [canonicalToken])
+  }, [unsupportedAsset, canonicalToken])
 
   useEffect(() => {
     let isSubscribed = true
     const update = async () => {
       try {
         setReserveTotalsUsd(undefined)
-        if (!(selectedNetwork && canonicalToken && tokenUsdPrice)) {
+        if (!(selectedNetwork && canonicalToken && tokenUsdPrice && !unsupportedAsset?.chain)) {
           return
         }
 
@@ -286,11 +291,11 @@ const PoolsContextProvider: FC = ({ children }) => {
     return () => {
       isSubscribed = false
     }
-  }, [selectedNetwork, canonicalToken, tokenUsdPrice])
+  }, [unsupportedAsset, selectedNetwork, canonicalToken, tokenUsdPrice])
 
   useEffect(() => {
-    if (!l2Networks.includes(selectedNetwork)) {
-      setSelectedNetwork(l2Networks[0])
+    if (selectedNetwork && !l2Networks.includes(selectedNetwork)) {
+      setSelectedNetwork(l2Networks[2])
     }
   }, [l2Networks])
 
@@ -298,7 +303,7 @@ const PoolsContextProvider: FC = ({ children }) => {
     let isSubscribed = true
     const update = async () => {
       try {
-        if (!(selectedBridge && selectedNetwork)) {
+        if (!(selectedBridge && selectedNetwork && !unsupportedAsset?.chain)) {
           setApr(undefined)
           return
         }
@@ -355,10 +360,10 @@ const PoolsContextProvider: FC = ({ children }) => {
     return () => {
       isSubscribed = false
     }
-  }, [sdk, selectedBridge, selectedNetwork])
+  }, [unsupportedAsset, sdk, selectedBridge, selectedNetwork])
 
   const priceImpact = useAsyncMemo(async () => {
-    if (!(canonicalToken && hopToken && selectedNetwork)) {
+    if (!(canonicalToken && hopToken && selectedNetwork && !unsupportedAsset?.chain)) {
       return
     }
     try {
@@ -371,13 +376,13 @@ const PoolsContextProvider: FC = ({ children }) => {
     } catch (err) {
       // noop
     }
-  }, [sdk, canonicalToken, hopToken, selectedNetwork, token0Amount, token1Amount])
+  }, [unsupportedAsset, sdk, canonicalToken, hopToken, selectedNetwork, token0Amount, token1Amount])
 
   useEffect(() => {
     let isSubscribed = true
     const update = async () => {
       setVirutalPrice(undefined)
-      if (!canonicalToken) {
+      if (!canonicalToken || !selectedNetwork || unsupportedAsset?.chain) {
         return
       }
       try {
@@ -396,13 +401,13 @@ const PoolsContextProvider: FC = ({ children }) => {
     return () => {
       isSubscribed = false
     }
-  }, [sdk, canonicalToken, selectedNetwork])
+  }, [unsupportedAsset, sdk, canonicalToken, selectedNetwork])
 
   useEffect(() => {
     let isSubscribed = true
     const update = async () => {
       setFee(undefined)
-      if (!canonicalToken) {
+      if (!canonicalToken || !selectedNetwork || unsupportedAsset?.chain) {
         return
       }
       try {
@@ -421,11 +426,11 @@ const PoolsContextProvider: FC = ({ children }) => {
     return () => {
       isSubscribed = false
     }
-  }, [sdk, canonicalToken, selectedNetwork])
+  }, [unsupportedAsset, sdk, canonicalToken, selectedNetwork])
 
   const updatePrices = useCallback(async () => {
     try {
-      if (!(totalSupply && canonicalToken && poolReserves)) return
+      if (!(totalSupply && canonicalToken && poolReserves.length > 0 && !unsupportedAsset?.chain)) return
       if (Number(token1Rate)) {
         const price = new Price(token1Rate, '1')
         setToken0Price(price.toFixed(2))
@@ -436,8 +441,8 @@ const PoolsContextProvider: FC = ({ children }) => {
         let amount0 = 0
         let amount1 = 0
 
-        const reserve0 = Number(formatUnits(poolReserves[0].toString(), canonicalToken?.decimals))
-        const reserve1 = Number(formatUnits(poolReserves[1].toString(), canonicalToken.decimals))
+        const reserve0 = Number(formatUnits(poolReserves[0]?.toString(), canonicalToken?.decimals))
+        const reserve1 = Number(formatUnits(poolReserves[1]?.toString(), canonicalToken.decimals))
 
         if (token0Amount) {
           amount0 = (Number(token0Amount) * Number(totalSupply)) / reserve0
@@ -457,7 +462,7 @@ const PoolsContextProvider: FC = ({ children }) => {
     } catch (err) {
       logger.error(err)
     }
-  }, [token0Amount, totalSupply, token1Amount, token1Rate, poolReserves, canonicalToken])
+  }, [unsupportedAsset, token0Amount, totalSupply, token1Amount, token1Rate, poolReserves, canonicalToken])
 
   useEffect(() => {
     updatePrices()
@@ -467,7 +472,7 @@ const PoolsContextProvider: FC = ({ children }) => {
     let isSubscribed = true
     const update = async () => {
       setPoolReserves([])
-      if (!(canonicalToken && hopToken)) {
+      if (!(canonicalToken && hopToken && selectedNetwork && !unsupportedAsset?.chain)) {
         return
       }
       const bridge = await sdk.bridge(canonicalToken.symbol)
@@ -487,11 +492,11 @@ const PoolsContextProvider: FC = ({ children }) => {
     return () => {
       isSubscribed = false
     }
-  }, [canonicalToken, hopToken, selectedNetwork])
+  }, [unsupportedAsset, canonicalToken, hopToken, selectedNetwork])
 
   const updateUserPoolPositions = useCallback(async () => {
     try {
-      if (!(canonicalToken && provider && selectedNetwork.provider && poolReserves)) {
+      if (!(canonicalToken && provider && selectedNetwork?.provider && poolReserves && !unsupportedAsset?.chain)) {
         setToken1Rate('')
         setToken0Deposited(undefined)
         setToken1Deposited(undefined)
@@ -554,7 +559,7 @@ const PoolsContextProvider: FC = ({ children }) => {
     } catch (err) {
       logger.error(err)
     }
-  }, [provider, selectedNetwork, canonicalToken, hopToken])
+  }, [unsupportedAsset, provider, selectedNetwork, canonicalToken, hopToken])
 
   useEffect(() => {
     updateUserPoolPositions()
@@ -601,7 +606,7 @@ const PoolsContextProvider: FC = ({ children }) => {
       setError(null)
       const networkId = Number(selectedNetwork?.networkId)
       const isNetworkConnected = await checkConnectedNetworkId(networkId)
-      if (!isNetworkConnected) return
+      if (!isNetworkConnected || !selectedNetwork) return
 
       if (!(Number(token0Amount) || Number(token1Amount))) {
         return
@@ -695,9 +700,9 @@ const PoolsContextProvider: FC = ({ children }) => {
 
       setRemoving(true)
       const bridge = sdk.bridge(canonicalToken.symbol)
-      const amm = bridge.getAmm(selectedNetwork.slug)
+      const amm = bridge.getAmm(selectedNetwork!.slug)
       const saddleSwap = await amm.getSaddleSwap()
-      const lpToken = await bridge.getSaddleLpToken(selectedNetwork.slug)
+      const lpToken = await bridge.getSaddleLpToken(selectedNetwork!.slug)
       const lpTokenDecimals = await lpToken.decimals
       const token0Amount = token0Deposited
       const token1Amount = token1Deposited
@@ -774,7 +779,7 @@ const PoolsContextProvider: FC = ({ children }) => {
 
             return bridge
               .connect(signer as Signer)
-              .removeLiquidity(liquidityTokenAmount, selectedNetwork.slug, {
+              .removeLiquidity(liquidityTokenAmount, selectedNetwork!.slug, {
                 amount0Min,
                 amount1Min,
                 deadline: deadline(),
@@ -807,7 +812,7 @@ const PoolsContextProvider: FC = ({ children }) => {
 
             return bridge
               .connect(signer as Signer)
-              .removeLiquidityOneToken(tokenAmount, tokenIndex, selectedNetwork.slug, {
+              .removeLiquidityOneToken(tokenAmount, tokenIndex, selectedNetwork!.slug, {
                 amountMin: amountMin,
                 deadline: deadline(),
               })
@@ -825,7 +830,9 @@ const PoolsContextProvider: FC = ({ children }) => {
         )
       }
 
-      const res = await waitForTransaction(removeLiquidityTx, { networkName: selectedNetwork.slug })
+      const res = await waitForTransaction(removeLiquidityTx, {
+        networkName: selectedNetwork!.slug,
+      })
       if (res && 'replacementTx' in res) {
         setTxHash(res.replacementTx.hash)
       }


### PR DESCRIPTION
previously, when routing to the `/pool` or `/convert` routes,
the `selectedNetwork` would initialize as defaultL2Network (`l2Networks[0]`), causing
errors if the asset was set to `MATIC` (defaultL2Network = arbitrum)

![Screen Shot 2022-01-11 at 8 15 39 PM](https://user-images.githubusercontent.com/18040654/149059723-66f38629-548a-42ca-81e7-748b144e0cc5.png)

- fix `defaultL2Network`: `MATIC` not supported on arbitrum/optimism
- add checks for `unsupportedAsset`
- clean up types