### PR TITLE
hop-node: L2Bridge: Use Type 0 tx type for Polygon commitTransfers txs

### DIFF
--- a/packages/hop-node/src/watchers/PolygonBridgeWatcher.ts
+++ b/packages/hop-node/src/watchers/PolygonBridgeWatcher.ts
@@ -152,7 +152,6 @@ class PolygonBridgeWatcher extends BaseWatcher {
     )
 
     return await this.l1Wallet.sendTransaction({
-      type: 0,
       to: rootTunnel,
       value: tx.value,
       data: tx.data,
@@ -168,7 +167,6 @@ class PolygonBridgeWatcher extends BaseWatcher {
     })
 
     return await this.l1Wallet.sendTransaction({
-      type: 0,
       to: tx.to,
       value: tx.value,
       data: tx.data,

--- a/packages/hop-node/src/watchers/PolygonBridgeWatcher.ts
+++ b/packages/hop-node/src/watchers/PolygonBridgeWatcher.ts
@@ -152,6 +152,7 @@ class PolygonBridgeWatcher extends BaseWatcher {
     )
 
     return await this.l1Wallet.sendTransaction({
+      type: 0,
       to: rootTunnel,
       value: tx.value,
       data: tx.data,
@@ -167,6 +168,7 @@ class PolygonBridgeWatcher extends BaseWatcher {
     })
 
     return await this.l1Wallet.sendTransaction({
+      type: 0,
       to: tx.to,
       value: tx.value,
       data: tx.data,

--- a/packages/hop-node/src/watchers/classes/L2Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/L2Bridge.ts
@@ -280,9 +280,16 @@ export default class L2Bridge extends Bridge {
   commitTransfers = async (
     destinationChainId: number
   ): Promise<providers.TransactionResponse> => {
+    const txOverrides = await this.txOverrides()
+    if (this.chainSlug === Chain.Polygon) {
+      txOverrides.type = 0
+    }
+
     const tx = await this.l2BridgeContract.commitTransfers(
       destinationChainId,
-      await this.txOverrides()
+      {
+        ...txOverrides
+      }
     )
 
     return tx

--- a/packages/hop-node/src/watchers/classes/L2Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/L2Bridge.ts
@@ -287,9 +287,7 @@ export default class L2Bridge extends Bridge {
 
     const tx = await this.l2BridgeContract.commitTransfers(
       destinationChainId,
-      {
-        ...txOverrides
-      }
+      txOverrides
     )
 
     return tx

--- a/packages/hop-node/test/gasBoostSigner.test.ts
+++ b/packages/hop-node/test/gasBoostSigner.test.ts
@@ -188,7 +188,7 @@ describe('GasBoostTransaction', () => {
 
     const optimismProvider = getRpcProvider('optimism')
     expectDefined(optimismProvider)
-    const optimismSigner = new Wallet(privateKey, optimismProvider)
+    const optimismSigner = new Wallet(privateKey!, optimismProvider)
 
     gTx = new GasBoostTransaction(tx, optimismSigner, store)
 
@@ -196,4 +196,37 @@ describe('GasBoostTransaction', () => {
     expectedMaxGasPrice = parseUnits('500', 9)
     expect(maxGasPrice).toEqual(expectedMaxGasPrice)
   })
+})
+
+describe.skip('GasBoostTransaction', () => {
+  const store = new MemoryStore()
+  const provider = getRpcProvider('polygon')
+  expectDefined(provider)
+  expectDefined(privateKey)
+  const signer = new GasBoostSigner(privateKey, provider)
+
+  it('should use type 0', async () => {
+    const recipient = await signer.getAddress()
+    const tx = await signer.sendTransaction({
+      type: 0,
+      to: recipient,
+      value: '0'
+    })
+
+    expect(tx).toBeTruthy()
+    expect(tx.type).toBe(0)
+    expect(tx.gasPrice).toBeTruthy()
+  }, 10 * 60 * 1000)
+
+  it('should use type 1', async () => {
+    const recipient = await signer.getAddress()
+    const tx = await signer.sendTransaction({
+      to: recipient,
+      value: '0'
+    })
+
+    expect(tx).toBeTruthy()
+    expect(tx.type).toBe(2)
+    expect(tx.gasPrice).toBeFalsy()
+  }, 10 * 60 * 1000)
 })


### PR DESCRIPTION
- Uses `type: 0` for tx type for `commitTransfers` if source chain is polygon