### PR TITLE
sdk/ui: fix network switching and sufficient balance hook

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudfront": "^3.45.0",
     "@hop-protocol/core": "0.0.1-beta.59",
-    "@hop-protocol/sdk": "0.0.1-beta.289",
+    "@hop-protocol/sdk": "0.0.1-beta.290",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "4.0.0-alpha.60",

--- a/packages/frontend/src/contexts/Web3Context.tsx
+++ b/packages/frontend/src/contexts/Web3Context.tsx
@@ -1,4 +1,4 @@
-import React, { FC, createContext, useContext, useMemo, useState, useEffect } from 'react'
+import React, { FC, createContext, useContext, useMemo, useState, useEffect, useCallback } from 'react'
 import Onboard from 'bnc-onboard'
 import { ethers, Contract, BigNumber } from 'ethers'
 import Address from 'src/models/Address'
@@ -261,7 +261,7 @@ const Web3ContextProvider: FC = ({ children }) => {
   const walletConnected = !!address
 
   // TODO: cleanup
-  const checkConnectedNetworkId = async (networkId?: number): Promise<boolean> => {
+  const checkConnectedNetworkId = useCallback(async (networkId?: number): Promise<boolean> => {
     if (!networkId) return false
     const signerNetworkId = (await provider?.getNetwork())?.chainId
     logger.debug('checkConnectedNetworkId', networkId, signerNetworkId)
@@ -318,7 +318,7 @@ const Web3ContextProvider: FC = ({ children }) => {
     }
 
     return true
-  }
+  }, [provider, onboard])
 
   // TODO: cleanup
   const getWriteContract = async (contract?: Contract): Promise<Contract | undefined> => {

--- a/packages/frontend/src/hooks/useSufficientBalance.ts
+++ b/packages/frontend/src/hooks/useSufficientBalance.ts
@@ -6,7 +6,7 @@ import { toTokenDisplay } from 'src/utils'
 export function useSufficientBalance(
   token?: Token,
   amount?: BigNumber,
-  estimatedGasCost?: BigNumber,
+  estimatedGasCost: BigNumber = BigNumber.from(500_000),
   tokenBalance: BigNumber = BigNumber.from(0)
 ) {
   const [sufficientBalance, setSufficientBalance] = useState(false)
@@ -14,7 +14,7 @@ export function useSufficientBalance(
 
   useEffect(() => {
     async function checkEnoughBalance() {
-      if (!(token && estimatedGasCost && amount)) {
+      if (!(token && amount)) {
         setWarning('')
         return setSufficientBalance(false)
       }
@@ -48,6 +48,10 @@ export function useSufficientBalance(
         } to pay for tx fees or reduce the amount by approximately ${toTokenDisplay(diff)} ${
           token.symbol
         }`
+
+        if (!token.isNativeToken) {
+          message = `Insufficient balance to cover the cost of tx. Please add ${token.nativeTokenSymbol} to pay for tx fees.`
+        }
       } else if (!enoughTokenBalance) {
         message = `Insufficient ${token.symbol} balance.`
       }

--- a/packages/frontend/src/hooks/useSufficientBalance.ts
+++ b/packages/frontend/src/hooks/useSufficientBalance.ts
@@ -6,7 +6,7 @@ import { toTokenDisplay } from 'src/utils'
 export function useSufficientBalance(
   token?: Token,
   amount?: BigNumber,
-  estimatedGasCost: BigNumber = BigNumber.from(500_000),
+  estimatedGasCost?: BigNumber,
   tokenBalance: BigNumber = BigNumber.from(0)
 ) {
   const [sufficientBalance, setSufficientBalance] = useState(false)
@@ -25,6 +25,11 @@ export function useSufficientBalance(
       let message: string = ''
 
       const ntb = await token.getNativeTokenBalance()
+
+      if (!estimatedGasCost) {
+        const gasPrice = await token.signer.getGasPrice()
+        estimatedGasCost = BigNumber.from(200e3).mul(gasPrice || 1e9)
+      }
 
       if (token.isNativeToken) {
         totalCost = estimatedGasCost.add(amount)

--- a/packages/hop-node/package.json
+++ b/packages/hop-node/package.json
@@ -47,7 +47,7 @@
     "@ethersproject/hdnode": "^5.0.9",
     "@fxportal/maticjs-fxportal": "1.1.1",
     "@hop-protocol/core": "0.0.1-beta.59",
-    "@hop-protocol/sdk": "0.0.1-beta.289",
+    "@hop-protocol/sdk": "0.0.1-beta.290",
     "@maticnetwork/maticjs": "3.2.0",
     "@maticnetwork/maticjs-ethers": "1.0.0",
     "@slack/web-api": "^6.1.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hop-protocol/sdk",
-  "version": "0.0.1-beta.289",
+  "version": "0.0.1-beta.290",
   "description": "The Hop Protocol JavaScript SDK",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/sdk/src/Token.ts
+++ b/packages/sdk/src/Token.ts
@@ -233,6 +233,10 @@ class Token extends Base {
     return isEth || isMatic || isxDai
   }
 
+  get nativeTokenSymbol () {
+    return this.chain.nativeTokenSymbol
+  }
+
   public async getNativeTokenBalance (address?: string): Promise<BigNumber> {
     address = address ?? await this.getSignerAddress()
     if (!address) {

--- a/packages/sdk/src/config/metadata.ts
+++ b/packages/sdk/src/config/metadata.ts
@@ -11,27 +11,27 @@ export const metadata: any = {
     ethereum: {
       name: 'Ethereum',
       isLayer1: true,
-      nativeTokenSymbol: 'ETH',
+      nativeTokenSymbol: 'ETH'
     },
     arbitrum: {
       name: 'Arbitrum',
       isLayer1: false,
-      nativeTokenSymbol: 'ETH',
+      nativeTokenSymbol: 'ETH'
     },
     optimism: {
       name: 'Optimism',
       isLayer1: false,
-      nativeTokenSymbol: 'ETH',
+      nativeTokenSymbol: 'ETH'
     },
     gnosis: {
       name: 'Gnosis',
       isLayer1: false,
-      nativeTokenSymbol: 'XDAI',
+      nativeTokenSymbol: 'XDAI'
     },
     polygon: {
       name: 'Polygon',
       isLayer1: false,
-      nativeTokenSymbol: 'MATIC',
+      nativeTokenSymbol: 'MATIC'
     }
   }
 }

--- a/packages/sdk/src/config/metadata.ts
+++ b/packages/sdk/src/config/metadata.ts
@@ -10,23 +10,28 @@ export const metadata: any = {
   networks: {
     ethereum: {
       name: 'Ethereum',
-      isLayer1: true
+      isLayer1: true,
+      nativeTokenSymbol: 'ETH',
     },
     arbitrum: {
       name: 'Arbitrum',
-      isLayer1: false
+      isLayer1: false,
+      nativeTokenSymbol: 'ETH',
     },
     optimism: {
       name: 'Optimism',
-      isLayer1: false
+      isLayer1: false,
+      nativeTokenSymbol: 'ETH',
     },
     gnosis: {
       name: 'Gnosis',
-      isLayer1: false
+      isLayer1: false,
+      nativeTokenSymbol: 'XDAI',
     },
     polygon: {
       name: 'Polygon',
-      isLayer1: false
+      isLayer1: false,
+      nativeTokenSymbol: 'MATIC',
     }
   }
 }

--- a/packages/sdk/src/models/Chain.ts
+++ b/packages/sdk/src/models/Chain.ts
@@ -10,6 +10,7 @@ class Chain {
   slug: Slug | string = ''
   provider: Provider | null = null
   isL1: boolean = false
+  nativeTokenSymbol: string
 
   static Ethereum = newChain(ChainSlug.Ethereum)
   static Optimism = newChain(ChainSlug.Optimism)
@@ -45,6 +46,8 @@ class Chain {
     if (provider) {
       this.provider = provider
     }
+
+    this.nativeTokenSymbol = metadata.networks[this.slug].nativeTokenSymbol
   }
 
   equals (other: Chain) {

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,1 +1,1 @@
-export default '0.0.1-beta.289'
+export default '0.0.1-beta.290'

--- a/packages/stats-worker/package.json
+++ b/packages/stats-worker/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.29.0",
     "@hop-protocol/core": "0.0.1-beta.59",
-    "@hop-protocol/sdk": "0.0.1-beta.289",
+    "@hop-protocol/sdk": "0.0.1-beta.290",
     "@pinata/sdk": "^1.1.23",
     "@types/luxon": "^2.0.7",
     "@types/node": "^16.7.10",


### PR DESCRIPTION
previously, if a user manually switched networks prior to confirming triggering a send tx, the app would use an old `provider` instance in `checkConnectedNetworkId()`. this is now addressed by recreating the function via `useCallback` which depends on `provider`.

previously, if a user did not have enough native token to pay for tx fees, the tx buttons would not be enabled and the `useSufficientBalance` hook would not display a warning message to indicate the error. this was due to the `useSufficientBalance` hook depending on the value `estimatedGasCost`. however, because the user doesn't have enough gas, `estimatedGasCost` would be undefined because of failed tx. this is now addressed by setting a default estimated gas cost.

additionally, a new field `nativeTokenSymbol` is added to the chain metadata for ease of use