### PR TITLE
hop-node: GasBoostSigner: Check for reorg and rebroadcast transaction

### DIFF
--- a/packages/hop-node/src/cli/bondWithdrawal.ts
+++ b/packages/hop-node/src/cli/bondWithdrawal.ts
@@ -1,5 +1,4 @@
 import BondWithdrawalWatcher from 'src/watchers/BondWithdrawalWatcher'
-import { Chain } from 'src/constants'
 import {
   findWatcher,
   getWatchers

--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -22,6 +22,7 @@ enum State {
   Confirmed = 'confirmed',
   Boosted = 'boosted',
   MaxGasPriceReached = 'maxGasPriceReached',
+  Reorg = 'reorg',
   Error = 'error'
 }
 
@@ -34,16 +35,16 @@ type InflightItem = {
 type MarshalledItem = {
   id: string
   createdAt: number
-  txHash: string
+  txHash?: string
   type?: number
   from: string
   to: string
   data: string
   value: string
   nonce: number
-  gasPrice: string
-  maxFeePerGas: string
-  maxPriorityFeePerGas: string
+  gasPrice?: string
+  maxFeePerGas?: string
+  maxPriorityFeePerGas?: string
   gasLimit: string
 }
 
@@ -55,6 +56,7 @@ export type Options = {
   minPriorityFeePerGas: number
   priorityFeePerGasCap: number
   compareMarketGasPrice: boolean
+  reorgWaitConfirmations: number
 }
 
 type Type0GasData = {
@@ -88,10 +90,13 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
   chainSlug: string
   id: string
   createdAt: number
-  txHash: string
-  receipt: providers.TransactionReceipt
+  txHash?: string
+  receipt?: providers.TransactionReceipt
   private _is1559Supported: boolean // set to true if EIP-1559 type transactions are supported
   readonly minMultiplier: number = 1.10 // the minimum gas price multiplier that miners will accept for transaction replacements
+
+  reorgWaitConfirmations: number = 1
+  originalTxParams: providers.TransactionRequest
 
   type?: number
 
@@ -102,9 +107,9 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
   value: BigNumber // type 0 and 2 tx required property
   nonce: number // type 0 and 2 tx required property
   gasLimit: BigNumber // type 0 and 2 tx required property
-  gasPrice: BigNumber // type 0 tx required property
-  maxFeePerGas: BigNumber // type 2 tx required property
-  maxPriorityFeePerGas: BigNumber // type 2 tx required property
+  gasPrice?: BigNumber // type 0 tx required property
+  maxFeePerGas?: BigNumber // type 2 tx required property
+  maxPriorityFeePerGas?: BigNumber // type 2 tx required property
   chainId: number // type 0 and 2 tx required property
   confirmations: number = 0 // type 0 and 2 tx required property
 
@@ -115,6 +120,38 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
       this.store = store
     }
     this.createdAt = Date.now()
+    this.originalTxParams = tx
+    this.setOwnTxParams(tx)
+    this.id = this.generateId()
+    this.setOptions(options)
+
+    const chainSlug = getProviderChainSlug(this.signer.provider)
+    if (!chainSlug) {
+      throw new Error('chain slug not found for contract provider')
+    }
+    this.chainSlug = chainSlug
+    this.chainId = chainSlugToId(chainSlug)!
+    const tag = 'GasBoostTransaction'
+    let prefix = `${this.chainSlug} id: ${this.id}`
+    const transferId = this.decodeTransferId()
+    if (transferId) {
+      prefix = `${prefix} transferId: ${transferId}`
+    }
+    this.logger = new Logger({
+      tag,
+      prefix
+    })
+    this.logger.log('starting log')
+    this.notifier = new Notifier(
+      `GasBoost, label: ${prefix}, host: ${hostname}`
+    )
+  }
+
+  private generateId (): string {
+    return uuidv4()
+  }
+
+  private setOwnTxParams (tx: providers.TransactionRequest) {
     this.from = tx.from!
     this.to = tx.to!
     if (tx.type != null) {
@@ -142,34 +179,6 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     if (tx.gasLimit) {
       this.gasLimit = BigNumber.from(tx.gasLimit)
     }
-
-    this.id = this.generateId()
-    this.setOptions(options)
-
-    const chainSlug = getProviderChainSlug(this.signer.provider)
-    if (!chainSlug) {
-      throw new Error('chain slug not found for contract provider')
-    }
-    this.chainSlug = chainSlug
-    this.chainId = chainSlugToId(chainSlug)!
-    const tag = 'GasBoostTransaction'
-    let prefix = `${this.chainSlug} id: ${this.id}`
-    const transferId = this.decodeTransferId()
-    if (transferId) {
-      prefix = `${prefix} transferId: ${transferId}`
-    }
-    this.logger = new Logger({
-      tag,
-      prefix
-    })
-    this.logger.log('starting log')
-    this.notifier = new Notifier(
-      `GasBoost, label: ${prefix}, host: ${hostname}`
-    )
-  }
-
-  generateId (): string {
-    return uuidv4()
   }
 
   decodeTransferId (): string | undefined {
@@ -291,7 +300,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     // use passed in tx gas values if they were specified
     if (this.gasPrice) {
       gasFeeData.gasPrice = this.gasPrice
-    } else if (this.maxFeePerGas || this.maxPriorityFeePerGas) {
+    } else if (this.maxFeePerGas ?? this.maxPriorityFeePerGas) {
       if (this.maxFeePerGas) {
         gasFeeData.maxFeePerGas = this.maxFeePerGas
       }
@@ -361,7 +370,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     if (!this.isChainGasFeeBumpable()) {
       return marketGasPrice
     }
-    const prevGasPrice = this.gasPrice || marketGasPrice
+    const prevGasPrice = this.gasPrice ?? marketGasPrice
     const bumpedGasPrice = getBumpedGasPrice(prevGasPrice, multiplier)
     if (!this.compareMarketGasPrice) {
       return bumpedGasPrice
@@ -374,7 +383,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     if (!this.isChainGasFeeBumpable()) {
       return marketMaxPriorityFeePerGas
     }
-    const prevMaxPriorityFeePerGas = this.maxPriorityFeePerGas || marketMaxPriorityFeePerGas
+    const prevMaxPriorityFeePerGas = this.maxPriorityFeePerGas ?? marketMaxPriorityFeePerGas
     const minPriorityFeePerGas = this.getMinPriorityFeePerGas()
     let bumpedMaxPriorityFeePerGas = getBumpedBN(prevMaxPriorityFeePerGas, multiplier)
     bumpedMaxPriorityFeePerGas = BNMax(minPriorityFeePerGas, bumpedMaxPriorityFeePerGas)
@@ -450,6 +459,9 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     if (typeof options.compareMarketGasPrice === 'boolean') {
       this.compareMarketGasPrice = options.compareMarketGasPrice
     }
+    if (options.reorgWaitConfirmations) {
+      this.reorgWaitConfirmations = options.reorgWaitConfirmations
+    }
   }
 
   async wait (): Promise<providers.TransactionReceipt> {
@@ -505,6 +517,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     this.receipt = receipt
     this.emit(State.Confirmed, receipt)
     this.logger.debug(`confirmed tx: ${tx.hash}, boostIndex: ${this.boostIndex}, nonce: ${this.nonce.toString()}, ${this.getGasFeeDataAsString()}`)
+    this.watchForReorg()
   }
 
   private async getReceipt (txHash: string) {
@@ -680,8 +693,8 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
   private track (tx: providers.TransactionResponse) {
     this.logger.debug('tracking')
     const prevItem = this.getLatestInflightItem()
-    this.logger.debug(`tracking: prevItem ${JSON.stringify(prevItem)}`)
     if (prevItem) {
+      this.logger.debug(`tracking: prevItem ${JSON.stringify(prevItem)}`)
       prevItem.boosted = true
       this.logger.debug(`tracking boosted tx: ${tx.hash}, previous tx: ${prevItem.hash}, boostIndex: ${this.boostIndex}, nonce: ${this.nonce.toString()}, ${this.getGasFeeDataAsString()}`)
     } else {
@@ -761,6 +774,52 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
       isAlreadyKnown,
       isFeeTooLow
     }
+  }
+
+  private async watchForReorg () {
+    this.logger.debug('watchForReorg started')
+    while (true) {
+      try {
+        const confirmedBlockNumber = this.receipt!.blockNumber
+        const waitConfirmationsBlockNumber = confirmedBlockNumber + this.reorgWaitConfirmations
+        const { number: headBlockNumber } = await this.signer.provider!.getBlock('latest')
+        if (headBlockNumber >= waitConfirmationsBlockNumber) {
+          this.logger.debug('checking for tx receipt to see if reorg occured')
+          const receipt = await this.signer.provider!.getTransactionReceipt(this.hash)
+          if (receipt) {
+            this.logger.debug(`no reorg; receipt found after waiting reorgWaitConfirmations (${this.reorgWaitConfirmations})`)
+          } else {
+            this.logger.debug(`no transaction receipt found after waiting reorgWaitConfirmations (${this.reorgWaitConfirmations})`)
+            this.emit(State.Reorg, this.hash)
+            this.rebroadcast()
+          }
+          break
+        }
+      } catch (err) {
+        this.logger.error('watForReorg error:', err)
+      }
+      await wait(this.pollMs)
+    }
+  }
+
+  private rebroadcast () {
+    this.reset()
+    this.logger.debug('attempting to rebroadcast transaction')
+    this.send()
+  }
+
+  private reset () {
+    this.logger.debug('resetting tx state to original tx params')
+    this.started = false
+    this.boostIndex = 0
+    this.confirmations = 0
+    this.txHash = undefined
+    this.receipt = undefined
+    this.gasPrice = undefined
+    this.maxFeePerGas = undefined
+    this.maxPriorityFeePerGas = undefined
+    this.clearInflightTxs()
+    this.setOwnTxParams(this.originalTxParams)
   }
 }
 

--- a/packages/hop-node/src/wallets/wallets.ts
+++ b/packages/hop-node/src/wallets/wallets.ts
@@ -17,14 +17,16 @@ const constructWallet = memoize(
       throw new Error('private key is required to instantiate wallet')
     }
     const provider = getRpcProvider(network)
-    const signer = new GasBoostSigner(privateKey, provider!) // eslint-disable-line
+    const signer = new GasBoostSigner(privateKey, provider!)
     const maxGasPriceGwei = getNetworkMaxGasPrice(network)
+    const { waitConfirmations: reorgWaitConfirmations } = globalConfig.networks[network]!
     signer.setOptions({
       gasPriceMultiplier,
       maxGasPriceGwei,
       minPriorityFeePerGas,
       priorityFeePerGasCap,
-      timeTilBoostMs
+      timeTilBoostMs,
+      reorgWaitConfirmations
     })
     return signer
   }


### PR DESCRIPTION
- checks for receipt again after `waitConfirmations` and rebroadcasts using same nonce if reorg occurred (puts original tx through `send` flow again)
- tested logic with a test simulating reorg