### PR TITLE
Feature/gasboost nonce db

### DIFF
--- a/packages/hop-node/@types/level-party/index.d.ts
+++ b/packages/hop-node/@types/level-party/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'level-party'

--- a/packages/hop-node/package.json
+++ b/packages/hop-node/package.json
@@ -83,6 +83,7 @@
     "heapdump": "^0.3.15",
     "keythereum": "1.2.0",
     "level": "^7.0.1",
+    "level-party": "^5.1.1",
     "lodash": "^4.17.21",
     "lolcatjs": "^2.4.0",
     "luxon": "^1.28.0",

--- a/packages/hop-node/src/db/BaseDb.ts
+++ b/packages/hop-node/src/db/BaseDb.ts
@@ -1,6 +1,6 @@
 import Logger from 'src/logger'
 import groupBy from 'lodash/groupBy'
-import level from 'level'
+import level from 'level-party'
 import merge from 'lodash/merge'
 import mkdirp from 'mkdirp'
 import os from 'os'

--- a/packages/hop-node/src/db/GasBoostDb.ts
+++ b/packages/hop-node/src/db/GasBoostDb.ts
@@ -1,0 +1,18 @@
+import BaseDb from './BaseDb'
+
+class GasBoostDb extends BaseDb {
+  async updateItem (key: string, data: any): Promise<void> {
+    await this._update(key, data)
+  }
+
+  async getItem (key: string): Promise<any> {
+    const item = await this.getById(key)
+    return item
+  }
+
+  async deleteItem (key: string): Promise<void> {
+    await this.deleteById(key)
+  }
+}
+
+export default GasBoostDb

--- a/packages/hop-node/src/db/db.ts
+++ b/packages/hop-node/src/db/db.ts
@@ -1,3 +1,4 @@
+import GasBoostDb from './GasBoostDb'
 import GasCostDb from './GasCostDb'
 import SyncStateDb from './SyncStateDb'
 import TransferRootsDb from './TransferRootsDb'
@@ -10,6 +11,9 @@ const dbSets: {[db: string]: {[tokenSymbol: string]: any}} = {
   transferRootsDb: {},
   gasCostDb: {}
 }
+
+// gasBoostDbs are chain specific instances
+const gasBoostDbs: {[chain: string]: any} = {}
 
 type Db = SyncStateDb | TransferRootsDb | TransfersDb | GasCostDb
 export type DbSet = {
@@ -51,4 +55,11 @@ export function getDbSet (tokenSymbol: string): DbSet {
       return dbSets.gasCostDb[tokenSymbol]
     }
   }
+}
+
+export function getGasBoostDb (chain: string): GasBoostDb {
+  if (!gasBoostDbs[chain]) {
+    gasBoostDbs[chain] = new GasBoostDb('gasBoost', chain)
+  }
+  return gasBoostDbs[chain]
 }

--- a/packages/hop-node/src/gasboost/GasBoostSigner.ts
+++ b/packages/hop-node/src/gasboost/GasBoostSigner.ts
@@ -71,10 +71,8 @@ class GasBoostSigner extends Wallet {
   }
 
   private async setLatestNonce () {
-    const dbNonce = await this.getDbNonce()
     const onChainNonce = await this.getOnChainNonce()
-    const nonce = Math.max(dbNonce, onChainNonce)
-    await this.setDbNonce(nonce)
+    await this.setDbNonce(onChainNonce)
   }
 
   // this is a required ethers Signer method

--- a/packages/hop-node/src/gasboost/GasBoostSigner.ts
+++ b/packages/hop-node/src/gasboost/GasBoostSigner.ts
@@ -1,8 +1,9 @@
-import GasBoostTransaction from './GasBoostTransaction'
 import GasBoostTransactionFactory, { Options } from './GasBoostTransactionFactory'
 import Logger from 'src/logger'
+import MemoryStore from './MemoryStore'
 import Store from './Store'
 import getProviderChainSlug from 'src/utils/getProviderChainSlug'
+import wait from 'src/utils/wait'
 import { Mutex } from 'async-mutex'
 import { NonceTooLowError } from 'src/types/error'
 import { Notifier } from 'src/notifier'
@@ -14,7 +15,6 @@ class GasBoostSigner extends Wallet {
   items: string[] = []
   lastTxSentTimestamp: number = 0
   delayBetweenTxsMs: number = 7 * 1000
-  nonce: number = 0
   chainSlug: string
   gTxFactory: GasBoostTransactionFactory
   signer: Signer
@@ -22,8 +22,9 @@ class GasBoostSigner extends Wallet {
   logger: Logger
   notifier: Notifier
   mutex: Mutex
+  ready: boolean = false
 
-  constructor (privateKey: string, provider?: providers.Provider, store?: Store, options: Partial<Options> = {}) {
+  constructor (privateKey: string, provider?: providers.Provider, store: Store = new MemoryStore(), options: Partial<Options> = {}) {
     super(privateKey, provider)
     this.signer = new Wallet(privateKey, provider)
     if (store != null) {
@@ -35,7 +36,7 @@ class GasBoostSigner extends Wallet {
     }
     this.chainSlug = chainSlug
     this.mutex = new Mutex()
-    this.gTxFactory = new GasBoostTransactionFactory(this.signer, this.store)
+    this.gTxFactory = new GasBoostTransactionFactory(this.signer)
     const tag = 'GasBoostSigner'
     const prefix = `${this.chainSlug}`
     this.logger = new Logger({
@@ -46,28 +47,51 @@ class GasBoostSigner extends Wallet {
       `GasBoostSigner, label: ${prefix}, host: ${hostname}`
     )
     this.setOptions(options)
-    this.restore()
+    this.init()
+      .catch((err: Error) => this.logger.error('init error:', err))
+      .finally(async () => {
+        const nonce = await this.getDbNonce()
+        this.logger.debug('ready')
+        this.logger.debug(`current nonce: ${nonce}`)
+        this.ready = true
+      })
   }
 
-  setStore (store: Store) {
-    this.store = store
+  private async init () {
+    await this.setLatestNonce()
+  }
+
+  protected async tilReady (): Promise<boolean> {
+    if (this.ready) {
+      return true
+    }
+
+    await wait(100)
+    return await this.tilReady()
+  }
+
+  private async setLatestNonce () {
+    const dbNonce = await this.getDbNonce()
+    const onChainNonce = await this.getOnChainNonce()
+    const nonce = Math.max(dbNonce, onChainNonce)
+    await this.setDbNonce(nonce)
   }
 
   // this is a required ethers Signer method
   async sendTransaction (tx: providers.TransactionRequest): Promise<providers.TransactionResponse> {
+    await this.tilReady()
     return await this.mutex.runExclusive(async () => {
       this.logger.debug(`unlocked tx: ${JSON.stringify(tx)}`)
       return await this._sendTransaction(tx)
     })
   }
 
-  _sendTransaction = async (tx: providers.TransactionRequest): Promise<providers.TransactionResponse> => {
-    const nonce = await this.getNonce()
+  private readonly _sendTransaction = async (tx: providers.TransactionRequest): Promise<providers.TransactionResponse> => {
+    const nonce = await this.getDbNonce()
     if (!tx.nonce) {
       tx.nonce = nonce
     }
     const gTx = this.gTxFactory.createTransaction(tx)
-    this.track(gTx)
     await gTx.save()
     try {
       await gTx.send()
@@ -75,43 +99,37 @@ class GasBoostSigner extends Wallet {
       // if nonce too low then we still want to increment the tracked nonce
       // before throwing error
       if (err instanceof NonceTooLowError) {
-        this.nonce++
-        this.logger.debug(`increment for NonceTooLowError. new nonce ${this.nonce}`)
+        await this.incNonce()
+        const newNonce = await this.getDbNonce()
+        this.logger.debug(`increment for NonceTooLowError. new nonce ${newNonce}`)
       }
       throw err
     }
-    this.nonce++
+    await this.incNonce()
     this.lastTxSentTimestamp = Date.now()
     return gTx
   }
 
-  private async getNonce () {
-    if (!this.nonce) {
-      this.nonce = await this.signer.getTransactionCount('pending')
-    }
-
-    return this.nonce
+  private async getOnChainNonce () {
+    return this.signer.getTransactionCount('pending')
   }
 
-  private async restore () {
-    if (!this.store) {
-      return
+  private async getDbNonce () {
+    const item = await this.store.getItem('nonce')
+    if (item?.nonce) {
+      return item.nonce
     }
-    const items = await this.store.getItems()
-    if (items) {
-      for (const item of items) {
-        const gTx = await this.gTxFactory.getTransactionFromId(item.id)
-        this.items.push(gTx.id)
-      }
-    }
+    return 0
   }
 
-  private track (gTx: GasBoostTransaction) {
-    if (!this.store) {
-      return
-    }
-    this.items.push(gTx.id)
-    this.store.updateItem(gTx.id, gTx.marshal())
+  private async incNonce () {
+    let nonce = await this.getDbNonce()
+    nonce++
+    await this.setDbNonce(nonce)
+  }
+
+  private async setDbNonce (nonce: number) {
+    await this.store.updateItem('nonce', { nonce })
   }
 
   setPollMs (pollMs: number) {

--- a/packages/hop-node/src/gasboost/GasBoostSigner.ts
+++ b/packages/hop-node/src/gasboost/GasBoostSigner.ts
@@ -116,10 +116,7 @@ class GasBoostSigner extends Wallet {
 
   private async getDbNonce () {
     const item = await this.store.getItem('nonce')
-    if (item?.nonce) {
-      return item.nonce
-    }
-    return 0
+    return item?.nonce ?? 0
   }
 
   private async incNonce () {

--- a/packages/hop-node/src/gasboost/MemoryStore.ts
+++ b/packages/hop-node/src/gasboost/MemoryStore.ts
@@ -8,10 +8,6 @@ export default class MemoryStore {
     return this.items[key]
   }
 
-  async getItems (): Promise<any[]> {
-    return Object.values(this.items)
-  }
-
   async deleteItem (key: string): Promise<void> {
     delete this.items[key]
   }

--- a/packages/hop-node/src/gasboost/Store.ts
+++ b/packages/hop-node/src/gasboost/Store.ts
@@ -1,6 +1,5 @@
 export default interface Store {
   updateItem: (key: string, value: any) => Promise<void>
   getItem: (key: string) => Promise<any>
-  getItems: () => Promise<any[]>
   deleteItem: (key: string) => Promise<void>
 }

--- a/packages/hop-node/src/wallets/wallets.ts
+++ b/packages/hop-node/src/wallets/wallets.ts
@@ -10,14 +10,16 @@ import {
   priorityFeePerGasCap,
   timeTilBoostMs
 } from 'src/config'
+import { getGasBoostDb } from 'src/db'
 
 const constructWallet = memoize(
   (network: string, privateKey: string): Wallet => {
     if (!privateKey) {
       throw new Error('private key is required to instantiate wallet')
     }
+    const db = getGasBoostDb(network)
     const provider = getRpcProvider(network)
-    const signer = new GasBoostSigner(privateKey, provider!)
+    const signer = new GasBoostSigner(privateKey, provider!, db)
     const maxGasPriceGwei = getNetworkMaxGasPrice(network)
     const { waitConfirmations: reorgWaitConfirmations } = globalConfig.networks[network]!
     signer.setOptions({


### PR DESCRIPTION
- [x] use db to store nonce state and read nonce state (removes in-memory nonce state)
- [x] on init, read on-chain pending nonce and compare against db nonce. Set current nonce to which ever is highest
- [x] uses [`level-party`](https://github.com/Level/party) (official lib by level team) to work around db locks 

An example script to show how 2 separate node process can access the db at the same time

```js
const level = require('level-party')
const wait = require('wait')
const db = level(__dirname + '/data', { valueEncoding: 'json' })
const reset = process.argv[2]

async function main() {
  if (reset) {
    await db.put('nonce', {nonce: 1})
    for (let i = 0; i < 10; i++) {
      const key = 'nonce'
      await wait(1000)
      let { nonce } = await db.get(key)
      console.log('nonce used', { nonce} )
      let value = {nonce: ++nonce}
      await db.put(key, value)
      console.log('set', key, '=', await db.get(key))
    }
  } else {
    const key = 'nonce'
    let { nonce } = await db.get(key)
    console.log('nonce used', nonce)
    let value = {nonce: ++nonce}
    await db.put(key, value)
    console.log('set', key, '=', await db.get(key))
  }
}

main()
```

The top half is simulating the bonder that is always running.
The bottom half simulating one-off txs as separate command.

![Peek 2022-03-07 18-04](https://user-images.githubusercontent.com/168240/157151638-51134336-5ba3-4a15-b9ec-ca69f7d6742c.gif)

```
$ node test.js
nonce used { nonce: 1 }
set nonce = { nonce: 2 }
nonce used { nonce: 2 }
set nonce = { nonce: 3 }
nonce used { nonce: 3 }
set nonce = { nonce: 4 }
nonce used { nonce: 5 }
set nonce = { nonce: 6 }
nonce used { nonce: 6 }
set nonce = { nonce: 7 }
nonce used { nonce: 8 }
set nonce = { nonce: 9 }
nonce used { nonce: 9 }
set nonce = { nonce: 10 }
nonce used { nonce: 10 }
set nonce = { nonce: 11 }
nonce used { nonce: 11 }
set nonce = { nonce: 12 }
nonce used { nonce: 12 }
set nonce = { nonce: 13 }
```

```
$ node test.js
nonce used 4
set nonce = { nonce: 5 }

$ node test.js
nonce used 7
set nonce = { nonce: 8 }
```

Notice how `nonce used` is never repeated by either process, as expected

You can also run multiple instances of bonder node on same db to try it out

I've confirmed it works with docker