### PR TITLE
Feature/hop node db getter return types

### DIFF
--- a/packages/hop-node/src/cli/commitTransfers.ts
+++ b/packages/hop-node/src/cli/commitTransfers.ts
@@ -33,5 +33,5 @@ async function main (source: any) {
   }
 
   const destinationChainId = chainSlugToId(destinationChain)
-  await watcher.checkIfShouldCommit(destinationChainId!)
+  await watcher.checkIfShouldCommit(destinationChainId)
 }

--- a/packages/hop-node/src/cli/pendingTransfers.ts
+++ b/packages/hop-node/src/cli/pendingTransfers.ts
@@ -30,7 +30,7 @@ async function main (source: any) {
     throw new Error('watcher not found')
   }
 
-  const destinationChainId = chainSlugToId(destinationChain)!
+  const destinationChainId = chainSlugToId(destinationChain)
   const bridge = (watcher.bridge as L2Bridge)
   const exists = await bridge.doPendingTransfersExist(destinationChainId)
   if (!exists) {

--- a/packages/hop-node/src/cli/send.ts
+++ b/packages/hop-node/src/cli/send.ts
@@ -224,7 +224,7 @@ async function sendTokens (
 
   const formattedAmount = (await bridge.formatUnits(parsedAmount)).toString()
   logger.debug(`attempting to send ${formattedAmount} ${label} ⟶  ${toChain} to ${recipient}`)
-  const destinationChainId = chainSlugToId(toChain)!
+  const destinationChainId = chainSlugToId(toChain)
   if (fromChain === Chain.Ethereum) {
     if (isHToken) {
       tx = await (bridge as L1Bridge).convertCanonicalTokenToHopToken(

--- a/packages/hop-node/src/cli/stake.ts
+++ b/packages/hop-node/src/cli/stake.ts
@@ -67,7 +67,7 @@ async function sendTokensToL2 (
 
   logger.debug('Sending tokens to L2')
   tx = await bridge.convertCanonicalTokenToHopToken(
-    chainSlugToId(chain)!,
+    chainSlugToId(chain),
     parsedAmount,
     recipient
   )

--- a/packages/hop-node/src/db/TransferRootsDb.ts
+++ b/packages/hop-node/src/db/TransferRootsDb.ts
@@ -56,6 +56,33 @@ type GetItemsFilter = Partial<TransferRoot> & {
   destinationChainIds?: number[]
 }
 
+type UnsettledTransferRoot = {
+  transferRootId: string
+  transferRootHash: string
+  totalAmount: BigNumber
+  transferIds: string[]
+  destinationChainId: number
+  rootSetTxHash: string
+  committed: boolean
+  committedAt: number
+  allSettled: boolean
+}
+
+type UnbondedTransferRoot = {
+  bonded: boolean
+  bondedAt: number
+  confirmed: boolean
+  transferRootHash: string
+  transferRootId: string
+  committedAt: number
+  commitTxHash: string
+  commitTxBlockNumber: number
+  destinationChainId: number
+  sourceChainId: number
+  totalAmount: BigNumber
+  transferIds: string[]
+}
+
 // structure:
 // key: `transferRoot:<committedAt>:<transferRootId>`
 // value: `{ transferRootId: <transferRootId> }`
@@ -352,10 +379,10 @@ class TransferRootsDb extends BaseDb {
 
   async getUnbondedTransferRoots (
     filter: GetItemsFilter = {}
-  ): Promise<TransferRoot[]> {
+  ): Promise<UnbondedTransferRoot[]> {
     await this.tilReady()
     const transferRoots: TransferRoot[] = await this.getTransferRootsFromTwoWeeks()
-    return transferRoots.filter(item => {
+    const filtered = transferRoots.filter(item => {
       if (!this.isRouteOk(filter, item)) {
         return false
       }
@@ -392,6 +419,8 @@ class TransferRootsDb extends BaseDb {
         timestampOk
       )
     })
+
+    return filtered as UnbondedTransferRoot[]
   }
 
   async getExitableTransferRoots (
@@ -547,10 +576,10 @@ class TransferRootsDb extends BaseDb {
 
   async getUnsettledTransferRoots (
     filter: GetItemsFilter = {}
-  ): Promise<TransferRoot[]> {
+  ): Promise<UnsettledTransferRoot[]> {
     await this.tilReady()
     const transferRoots: TransferRoot[] = await this.getTransferRootsFromTwoWeeks()
-    return transferRoots.filter(item => {
+    const filtered = transferRoots.filter(item => {
       if (!this.isRouteOk(filter, item)) {
         return false
       }
@@ -595,6 +624,8 @@ class TransferRootsDb extends BaseDb {
         settleAttemptTimestampOk
       )
     })
+
+    return filtered as UnsettledTransferRoot[]
   }
 
   async getIncompleteItems (

--- a/packages/hop-node/src/db/TransfersDb.ts
+++ b/packages/hop-node/src/db/TransfersDb.ts
@@ -52,6 +52,32 @@ type GetItemsFilter = Partial<Transfer> & {
   destinationChainIds?: number[]
 }
 
+export type UnbondedSentTransfer = {
+  transferId: string
+  transferSentTimestamp: number
+  withdrawalBonded: boolean
+  transferSentTxHash: string
+  isBondable: boolean
+  isTransferSpent: boolean
+  destinationChainId: number
+  amount: BigNumber
+  withdrawalBondTxError: TxError
+  sourceChainId: number
+  recipient: string
+  amountOutMin: BigNumber
+  bonderFee: BigNumber
+  transferNonce: string
+  deadline: BigNumber
+}
+
+export type UncommittedTransfer = {
+  transferId: string
+  transferRootId: string
+  transferSentTxHash: string
+  committed: boolean
+  destinationChainId: number
+}
+
 // structure:
 // key: `transfer:<transferSentTimestamp>:<transferId>`
 // value: `{ transferId: <transferId> }`
@@ -344,9 +370,9 @@ class TransfersDb extends BaseDb {
 
   async getUncommittedTransfers (
     filter: GetItemsFilter = {}
-  ): Promise<Transfer[]> {
+  ): Promise<UncommittedTransfer[]> {
     const transfers: Transfer[] = await this.getTransfersFromWeek()
-    return transfers.filter(item => {
+    const filtered = transfers.filter(item => {
       if (!this.isRouteOk(filter, item)) {
         return false
       }
@@ -358,13 +384,15 @@ class TransfersDb extends BaseDb {
         !item.committed
       )
     })
+
+    return filtered as UncommittedTransfer[]
   }
 
   async getUnbondedSentTransfers (
     filter: GetItemsFilter = {}
-  ): Promise<Transfer[]> {
+  ): Promise<UnbondedSentTransfer[]> {
     const transfers: Transfer[] = await this.getTransfersFromWeek()
-    return transfers.filter(item => {
+    const filtered = transfers.filter(item => {
       if (!item?.transferId) {
         return false
       }
@@ -403,6 +431,8 @@ class TransfersDb extends BaseDb {
         timestampOk
       )
     })
+
+    return filtered as UnbondedSentTransfer[]
   }
 
   async getIncompleteItems (

--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -130,7 +130,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
       throw new Error('chain slug not found for contract provider')
     }
     this.chainSlug = chainSlug
-    this.chainId = chainSlugToId(chainSlug)!
+    this.chainId = chainSlugToId(chainSlug)
     const tag = 'GasBoostTransaction'
     let prefix = `${this.chainSlug} id: ${this.id}`
     const transferId = this.decodeTransferId()

--- a/packages/hop-node/src/theGraph/getIncompleteSettlements.ts
+++ b/packages/hop-node/src/theGraph/getIncompleteSettlements.ts
@@ -31,7 +31,7 @@ type BondedTransfer = {
 }
 
 export default async function getIncompleteSettlements (token: string, chain: string, destinationChain: string): Promise<any> {
-  const destinationChainId: number = chainSlugToId(destinationChain)! // eslint-disable-line
+  const destinationChainId: number = chainSlugToId(destinationChain)
 
   const isDestinationOptimism = destinationChain === Chain.Optimism
   if (isDestinationOptimism) {

--- a/packages/hop-node/src/theGraph/getUnbondedTransferRoots.ts
+++ b/packages/hop-node/src/theGraph/getUnbondedTransferRoots.ts
@@ -3,7 +3,7 @@ import makeRequest from './makeRequest'
 import { DateTime } from 'luxon'
 
 export default async function getUnbondedTransferRoots (chain: string, token: string, destinationChain: string): Promise<any> {
-  const destinationChainId: number = chainSlugToId(destinationChain)! // eslint-disable-line
+  const destinationChainId: number = chainSlugToId(destinationChain)
 
   let query = getTransfersCommittedsQuery(token)
   const transfersCommittedRes = await makeRequest(chain, query, {

--- a/packages/hop-node/src/utils/chainSlugToId.ts
+++ b/packages/hop-node/src/utils/chainSlugToId.ts
@@ -1,9 +1,11 @@
 import { config as globalConfig } from 'src/config'
 
-const chainSlugToId = (network: string): number | undefined => {
-  return (
-    globalConfig.networks[network]?.networkId ?? globalConfig.networks[network]?.chainId
-  )
+const chainSlugToId = (network: string): number => {
+  const chainId = globalConfig.networks[network]?.networkId ?? globalConfig.networks[network]?.chainId
+  if (!chainId) {
+    throw new Error(`chain ID for ${network} not found`)
+  }
+  return chainId
 }
 
 export default chainSlugToId

--- a/packages/hop-node/src/watchers/AvailableLiquidityWatcher.ts
+++ b/packages/hop-node/src/watchers/AvailableLiquidityWatcher.ts
@@ -133,7 +133,7 @@ class AvailableLiquidityWatcher extends BaseWatcher {
         continue
       }
 
-      totalAmount = totalAmount.add(transferRoot.totalAmount!)
+      totalAmount = totalAmount.add(transferRoot.totalAmount)
     }
 
     return totalAmount

--- a/packages/hop-node/src/watchers/BondTransferRootWatcher.ts
+++ b/packages/hop-node/src/watchers/BondTransferRootWatcher.ts
@@ -57,24 +57,24 @@ class BondTransferRootWatcher extends BaseWatcher {
       const logger = this.logger.create({ root: transferRootId })
 
       const bondChainId = chainSlugToId(Chain.Ethereum)
-      const availableCredit = this.getAvailableCreditForBond(bondChainId!)
-      const notEnoughCredit = availableCredit.lt(totalAmount!)
+      const availableCredit = this.getAvailableCreditForBond(bondChainId)
+      const notEnoughCredit = availableCredit.lt(totalAmount)
       if (notEnoughCredit) {
         logger.debug(
         `not enough credit to bond transferRoot. Have ${this.bridge.formatUnits(
           availableCredit
-        )}, need ${this.bridge.formatUnits(totalAmount!)}`)
+        )}, need ${this.bridge.formatUnits(totalAmount)}`)
         continue
       }
 
       promises.push(this.checkTransfersCommitted(
         transferRootId,
-        transferRootHash!,
-        totalAmount!,
-        destinationChainId!,
-        committedAt!,
-        sourceChainId!,
-        transferIds!
+        transferRootHash,
+        totalAmount,
+        destinationChainId,
+        committedAt,
+        sourceChainId,
+        transferIds
       ))
     }
 
@@ -137,7 +137,7 @@ class BondTransferRootWatcher extends BaseWatcher {
 
     const bondChainId = chainSlugToId(Chain.Ethereum)
     const bondAmount = await l1Bridge.getBondForTransferAmount(totalAmount)
-    const availableCredit = this.getAvailableCreditForBond(bondChainId!)
+    const availableCredit = this.getAvailableCreditForBond(bondChainId)
     const notEnoughCredit = availableCredit.lt(bondAmount)
     if (notEnoughCredit) {
       const msg = `not enough credit to bond transferRoot. Have ${this.bridge.formatUnits(

--- a/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/BondWithdrawalWatcher.ts
@@ -11,6 +11,7 @@ import { BonderFeeTooLowError, NonceTooLowError } from 'src/types/error'
 import { L1Bridge as L1BridgeContract } from '@hop-protocol/core/contracts/L1Bridge'
 import { L2Bridge as L2BridgeContract } from '@hop-protocol/core/contracts/L2Bridge'
 import { TxError } from 'src/constants'
+import { UnbondedSentTransfer } from 'src/db/TransfersDb'
 import { config as globalConfig } from 'src/config'
 
 type Config = {
@@ -62,12 +63,12 @@ class BondWithdrawalWatcher extends BaseWatcher {
         withdrawalBondTxError
       } = dbTransfer
       const logger = this.logger.create({ id: transferId })
-      const availableCredit = this.getAvailableCreditForTransfer(destinationChainId!)
-      const notEnoughCredit = availableCredit.lt(amount!)
+      const availableCredit = this.getAvailableCreditForTransfer(destinationChainId)
+      const notEnoughCredit = availableCredit.lt(amount)
       const isUnbondable = notEnoughCredit && withdrawalBondTxError === TxError.NotEnoughLiquidity
       if (isUnbondable) {
         logger.warn(
-          `invalid credit or liquidity. availableCredit: ${availableCredit.toString()}, amount: ${amount!.toString()}`,
+          `invalid credit or liquidity. availableCredit: ${availableCredit.toString()}, amount: ${amount.toString()}`,
           `withdrawalBondTxError: ${withdrawalBondTxError}`
         )
 
@@ -85,7 +86,7 @@ class BondWithdrawalWatcher extends BaseWatcher {
   }
 
   async checkTransferId (transferId: string) {
-    const dbTransfer = await this.db.transfers.getByTransferId(transferId)
+    const dbTransfer = await this.db.transfers.getByTransferId(transferId) as UnbondedSentTransfer
     if (!dbTransfer) {
       this.logger.warn(`transfer id "${transferId}" not found in db`)
       return
@@ -109,7 +110,7 @@ class BondWithdrawalWatcher extends BaseWatcher {
     logger.debug('bonderFee:', bonderFee && this.bridge.formatUnits(bonderFee))
 
     const sourceL2Bridge = this.bridge as L2Bridge
-    const destBridge = this.getSiblingWatcherByChainId(destinationChainId!)
+    const destBridge = this.getSiblingWatcherByChainId(destinationChainId)
       .bridge
 
     logger.debug('processing bondWithdrawal. checking isTransferIdSpent')
@@ -123,7 +124,7 @@ class BondWithdrawalWatcher extends BaseWatcher {
 
     const isReceivingNativeToken = isNativeToken(destBridge.chainSlug, this.tokenSymbol)
     if (isReceivingNativeToken) {
-      const isRecipientReceivable = await this.getIsRecipientReceivable(recipient!, destBridge, logger)
+      const isRecipientReceivable = await this.getIsRecipientReceivable(recipient, destBridge, logger)
       logger.debug(`processing bondWithdrawal. isRecipientReceivable: ${isRecipientReceivable}`)
       if (!isRecipientReceivable) {
         logger.warn('recipient cannot receive transfer. marking item not bondable')
@@ -132,14 +133,14 @@ class BondWithdrawalWatcher extends BaseWatcher {
       }
     }
 
-    const availableCredit = this.getAvailableCreditForTransfer(destinationChainId!)
-    const notEnoughCredit = availableCredit.lt(amount!)
+    const availableCredit = this.getAvailableCreditForTransfer(destinationChainId)
+    const notEnoughCredit = availableCredit.lt(amount)
     logger.debug(`processing bondWithdrawal. availableCredit: ${availableCredit.toString()}`)
     if (notEnoughCredit) {
       logger.warn(
         `not enough credit to bond withdrawal. Have ${this.bridge.formatUnits(
           availableCredit
-        )}, need ${this.bridge.formatUnits(amount!)}`
+        )}, need ${this.bridge.formatUnits(amount)}`
       )
       await this.db.transfers.update(transferId, {
         withdrawalBondTxError: TxError.NotEnoughLiquidity
@@ -152,20 +153,20 @@ class BondWithdrawalWatcher extends BaseWatcher {
       return
     }
 
-    await this.withdrawFromVaultIfNeeded(destinationChainId!, amount!)
+    await this.withdrawFromVaultIfNeeded(destinationChainId, amount)
 
     logger.debug('attempting to send bondWithdrawal tx')
 
     const sourceTx = await sourceL2Bridge.getTransaction(
-      transferSentTxHash!
+      transferSentTxHash
     )
     if (!sourceTx) {
       this.logger.warn(`source tx data for tx hash "${transferSentTxHash}" not found. Cannot proceed`)
       return
     }
     const { from: sender, data } = sourceTx
-    const attemptSwap = this.bridge.shouldAttemptSwap(amountOutMin!, deadline!)
-    if (attemptSwap && isL1ChainId(destinationChainId!)) {
+    const attemptSwap = this.bridge.shouldAttemptSwap(amountOutMin, deadline)
+    if (attemptSwap && isL1ChainId(destinationChainId)) {
       logger.debug('marking as unbondable. Destination is L1 and attemptSwap is true')
       await this.db.transfers.update(transferId, {
         isBondable: false

--- a/packages/hop-node/src/watchers/ChallengeWatcher.ts
+++ b/packages/hop-node/src/watchers/ChallengeWatcher.ts
@@ -1,6 +1,7 @@
 import '../moduleAlias'
 import BaseWatcher from './classes/BaseWatcher'
 import L1Bridge from './classes/L1Bridge'
+import { ChallengeableTransferRoot } from 'src/db/TransferRootsDb'
 import { L1Bridge as L1BridgeContract } from '@hop-protocol/core/contracts/L1Bridge'
 import { L2Bridge as L2BridgeContract } from '@hop-protocol/core/contracts/L2Bridge'
 import { Notifier } from 'src/notifier'
@@ -54,10 +55,10 @@ class ChallengeWatcher extends BaseWatcher {
   async checkChallengeableTransferRoot (transferRootId: string) {
     const logger = this.logger.create({ root: transferRootId })
 
-    const { transferRootHash, totalAmount } = await this.db.transferRoots.getByTransferRootId(transferRootId)
+    const { transferRootHash, totalAmount } = await this.db.transferRoots.getByTransferRootId(transferRootId) as ChallengeableTransferRoot
     logger.debug('Challenging transfer root', transferRootId)
     logger.debug('transferRootHash:', transferRootHash)
-    logger.debug('totalAmount:', this.bridge.formatUnits(totalAmount!))
+    logger.debug('totalAmount:', this.bridge.formatUnits(totalAmount))
     logger.debug('transferRootId:', transferRootId)
 
     const dbTransferRoot = await this.db.transferRoots.getByTransferRootId(

--- a/packages/hop-node/src/watchers/CommitTransfersWatcher.ts
+++ b/packages/hop-node/src/watchers/CommitTransfersWatcher.ts
@@ -77,8 +77,8 @@ class CommitTransfersWatcher extends BaseWatcher {
     const destinationChainIds: number[] = []
     for (const dbTransfer of dbTransfers) {
       const { destinationChainId } = dbTransfer
-      if (!destinationChainIds.includes(destinationChainId!)) {
-        destinationChainIds.push(destinationChainId!)
+      if (!destinationChainIds.includes(destinationChainId)) {
+        destinationChainIds.push(destinationChainId)
       }
     }
     for (const destinationChainId of destinationChainIds) {

--- a/packages/hop-node/src/watchers/ContractStateWatcher.ts
+++ b/packages/hop-node/src/watchers/ContractStateWatcher.ts
@@ -55,7 +55,7 @@ class ContractStateWatcher {
       if (chain === Chain.Ethereum) {
         continue
       }
-      const chainId = chainSlugToId(chain)! // eslint-disable-line
+      const chainId = chainSlugToId(chain)
       if (!chainStates[chainId]) {
         chainStates[chainId] = {}
       }
@@ -138,7 +138,7 @@ class ContractStateWatcher {
     const chains = getEnabledNetworks()
     const chainStates: any = {}
     for (const chain of chains) {
-      const chainId = chainSlugToId(chain)! // eslint-disable-line
+      const chainId = chainSlugToId(chain)
       if (!chainStates[chainId]) {
         chainStates[chainId] = {}
       }

--- a/packages/hop-node/src/watchers/PolygonBridgeWatcher.ts
+++ b/packages/hop-node/src/watchers/PolygonBridgeWatcher.ts
@@ -45,7 +45,7 @@ class PolygonBridgeWatcher extends BaseWatcher {
     this.l1Provider = this.l1Wallet.provider
     this.l2Provider = this.l2Wallet.provider
 
-    this.chainId = chainSlugToId(config.chainSlug)! // eslint-disable-line
+    this.chainId = chainSlugToId(config.chainSlug)
     this.apiUrl = `https://apis.matic.network/api/v1/${
       this.chainId === this.polygonMainnetChainId ? 'matic' : 'mumbai'
     }/block-included`

--- a/packages/hop-node/src/watchers/SettleBondedWithdrawalWatcher.ts
+++ b/packages/hop-node/src/watchers/SettleBondedWithdrawalWatcher.ts
@@ -47,7 +47,7 @@ class SettleBondedWithdrawalWatcher extends BaseWatcher {
 
       // get all db transfer items that belong to root
       const dbTransfers: Transfer[] = []
-      for (const transferId of transferIds!) {
+      for (const transferId of transferIds) {
         const dbTransfer = await this.db.transfers.getByTransferId(transferId)
         if (!dbTransfer) {
           continue
@@ -55,8 +55,8 @@ class SettleBondedWithdrawalWatcher extends BaseWatcher {
         dbTransfers.push(dbTransfer)
       }
 
-      if (dbTransfers.length !== transferIds!.length) {
-        this.logger.error(`could not find all db transfers for root id ${transferRootId}. Has ${transferIds!.length}, found ${dbTransfers.length}. Db may not be fully synced`)
+      if (dbTransfers.length !== transferIds.length) {
+        this.logger.error(`could not find all db transfers for root id ${transferRootId}. Has ${transferIds.length}, found ${dbTransfers.length}. Db may not be fully synced`)
         continue
       }
 

--- a/packages/hop-node/src/watchers/classes/ContractBase.ts
+++ b/packages/hop-node/src/watchers/classes/ContractBase.ts
@@ -27,7 +27,7 @@ export default class ContractBase extends EventEmitter {
       throw new Error('chain slug not found for contract provider')
     }
     this.chainSlug = chainSlug
-    this.chainId = chainSlugToId(chainSlug)! // eslint-disable-line
+    this.chainId = chainSlugToId(chainSlug)
   }
 
   getChainId = async (): Promise<number> => {

--- a/packages/hop-node/src/watchers/watchers.ts
+++ b/packages/hop-node/src/watchers/watchers.ts
@@ -289,7 +289,7 @@ function getSiblingWatchers (config: GetSiblingWatchersConfig, init: (conf: GetS
   for (const tokenSymbol of tokens) {
     for (const chainSlug of networks) {
       const isL1 = chainSlug === Chain.Ethereum
-      const chainId = chainSlugToId(chainSlug)! // eslint-disable-line
+      const chainId = chainSlugToId(chainSlug)
       if (!contracts.has(tokenSymbol, chainSlug)) {
         continue
       }

--- a/packages/hop-node/src/watchers/xDomainMessageRelayWatcher.ts
+++ b/packages/hop-node/src/watchers/xDomainMessageRelayWatcher.ts
@@ -6,6 +6,7 @@ import L1Bridge from './classes/L1Bridge'
 import OptimismBridgeWatcher from './OptimismBridgeWatcher'
 import PolygonBridgeWatcher from './PolygonBridgeWatcher'
 import { Chain } from 'src/constants'
+import { ExitableTransferRoot } from 'src/db/TransferRootsDb'
 import { L1Bridge as L1BridgeContract } from '@hop-protocol/core/contracts/L1Bridge'
 import { L2Bridge as L2BridgeContract } from '@hop-protocol/core/contracts/L2Bridge'
 import { getEnabledNetworks } from 'src/config'
@@ -93,7 +94,7 @@ class xDomainMessageRelayWatcher extends BaseWatcher {
   }
 
   async checkTransfersCommitted (transferRootId: string) {
-    const dbTransferRoot = await this.db.transferRoots.getByTransferRootId(transferRootId)
+    const dbTransferRoot = await this.db.transferRoots.getByTransferRootId(transferRootId) as ExitableTransferRoot
     if (!dbTransferRoot) {
       throw new Error(`transfer root db item not found, root id "${transferRootId}"`)
     }
@@ -103,7 +104,7 @@ class xDomainMessageRelayWatcher extends BaseWatcher {
     const logger = this.logger.create({ root: transferRootId })
     const chainSlug = this.chainIdToSlug(await this.bridge.getChainId())
     const isTransferRootIdConfirmed = await this.l1Bridge.isTransferRootIdConfirmed(
-      destinationChainId!,
+      destinationChainId,
       transferRootId
     )
     if (isTransferRootIdConfirmed) {
@@ -121,7 +122,7 @@ class xDomainMessageRelayWatcher extends BaseWatcher {
     }
 
     logger.debug(`handling commit tx hash ${commitTxHash} from ${destinationChainId}`)
-    await watcher.handleCommitTxHash(commitTxHash!, transferRootId, logger)
+    await watcher.handleCommitTxHash(commitTxHash, transferRootId, logger)
   }
 }
 


### PR DESCRIPTION
- [x] add explicit db getter return types for TransfersDb and TransferRootsDb to avoid using `!`  non-null assertion operator when reading properties