### PR TITLE
UI: fix stats page

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -100,6 +100,7 @@
     "@types/react": "^17.0.31",
     "@types/react-dom": "^17.0.10",
     "@types/react-router-dom": "^5.3.1",
+    "@types/react-table": "^7.7.10",
     "@types/styled-components": "^5.1.14",
     "@types/styled-system": "^5.1.13",
     "@typescript-eslint/eslint-plugin": "^4.18.0",

--- a/packages/frontend/src/components/Table/Table.tsx
+++ b/packages/frontend/src/components/Table/Table.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useTable, useSortBy, sortTypes } from 'react-table'
+import { useTable, useSortBy } from 'react-table'
 import makeData from './makeData'
 import { Div } from '../ui'
-import { Loading } from '../Loading'
 
 const Styles = styled.div`
   padding: 0.25rem;
@@ -65,20 +64,10 @@ const Styles = styled.div`
 `
 
 function Table({ columns, data, loading }) {
-  const {
-    getTableProps,
-    getTableBodyProps,
-    headerGroups,
-    rows,
-    prepareRow,
-    state,
-    setHiddenColumns,
-    ...rest
-  } = useTable(
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = useTable(
     {
       columns,
       data,
-      sortTypes,
     },
     useSortBy
   )
@@ -87,36 +76,35 @@ function Table({ columns, data, loading }) {
     <Div>
       <table {...getTableProps()}>
         <thead>
-          {headerGroups.map((headerGroup, i) => (
+          {headerGroups.map((headerGroup: any, i) => (
             <tr
               {...headerGroup.getHeaderGroupProps([
                 {
                   style: {
                     ...headerGroup.style,
-                    textAlign: i === 0 && 'left',
-                    fontSize: i === 0 && '2rem',
-                    color: i === 0 && '#B32EFF',
+                    textAlign: i === 0 ? 'left' : 'center',
+                    fontSize: i === 0 ? '2rem' : '1.5rem',
+                    color: i === 0 ? '#B32EFF' : 'inherit',
                   },
                 },
               ])}
             >
-              {headerGroup.headers.map((column, i) => (
+              {headerGroup.headers.map((column: any, i) => (
                 // Add the sorting props to control sorting. For this example
                 // we can add them into the header props
                 <th
-                  {...column.getHeaderProps([
+                  {...column.getHeaderProps(column.getSortByToggleProps(), [
                     {
                       style: {
                         ...column.style,
-                        backgroundColor: column.isSorted ? '#eed0ff' : 'transparent',
+                        backgroundColor: (column as any).isSorted ? '#eed0ff' : 'transparent',
                       },
                     },
-                    column.getSortByToggleProps(),
                   ])}
                 >
                   {column.render('Header')}
                   <span style={{ color: '#B32EFF' }}>
-                    {column.isSorted ? (column.isSortedDesc ? ' ↑' : ' ↓') : ''}
+                    {column.isSorted ? ' ↑' : column.isSortedDesc && ' ↓'}
                   </span>
                 </th>
               ))}
@@ -125,16 +113,6 @@ function Table({ columns, data, loading }) {
         </thead>
 
         <tbody {...getTableBodyProps()}>
-          {/* {loading ? (<Loading />) : rows.map((row, i) => {
-            prepareRow(row)
-            return (
-              <tr {...row.getRowProps()}>
-                {row.cells.map(cell => {
-                  return <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
-                })}
-              </tr>
-            )
-          })} */}
           {rows.map((row, i) => {
             prepareRow(row)
             return (
@@ -164,7 +142,7 @@ function SortableTable(props: Props) {
 
   const data = React.useMemo(
     () => makeData(stats, populateDataFn, extraData),
-    [stats, extraData, populateDataFn, loading]
+    [stats, extraData, populateDataFn]
   )
 
   return (

--- a/packages/frontend/src/config/interfaces.ts
+++ b/packages/frontend/src/config/interfaces.ts
@@ -32,7 +32,7 @@ export interface HopAddresses {
 
 export type Networks = {
   [key: string]: {
-    networkId: string
+    networkId: number
     rpcUrl: string
     explorerUrl: string
     nativeBridgeUrl?: string

--- a/packages/frontend/src/hooks/useGnosisSafeTransaction.ts
+++ b/packages/frontend/src/hooks/useGnosisSafeTransaction.ts
@@ -56,7 +56,7 @@ export function useGnosisSafeTransaction(
 
   // Checks if source chain == gnosis-safe chain
   const isCorrectSignerNetwork = useMemo(() => {
-    return isSmartContractWallet && fromNetwork?.networkId === safe?.chainId.toString()
+    return isSmartContractWallet && fromNetwork?.networkId === safe?.chainId
   }, [isSmartContractWallet, fromNetwork, safe])
 
   // Display warnings to enforce valid source chain and custom recipient

--- a/packages/frontend/src/hooks/useSelectedNetwork.ts
+++ b/packages/frontend/src/hooks/useSelectedNetwork.ts
@@ -39,7 +39,7 @@ export function useSelectedNetwork(opts: Options = { l2Only: false }) {
   const isMatchingSignerAndSourceChainNetwork = useMemo(() => {
     if (queryParams?.sourceNetwork) {
       const chainId = networkSlugToId(queryParams.sourceNetwork as ChainSlug)
-      if (opts.gnosisSafe?.chainId.toString() === chainId) {
+      if (opts.gnosisSafe?.chainId === chainId) {
         return true
       }
     }

--- a/packages/frontend/src/models/Network.ts
+++ b/packages/frontend/src/models/Network.ts
@@ -8,9 +8,11 @@ export type NetworkProps = {
   slug: string
   imageUrl: string
   rpcUrl: string
-  networkId: string
+  networkId: number
+  chainId?: number
   nativeTokenSymbol: string
   isLayer1?: boolean
+  isL1?: boolean
   nativeBridgeUrl?: string
   waitConfirmations?: number
   explorerUrl: string
@@ -22,9 +24,11 @@ class Network {
   readonly imageUrl: string
   readonly provider: ethers.providers.Provider
   readonly rpcUrl: string
-  readonly networkId: string
+  readonly networkId: number
+  readonly chainId: number
   readonly nativeTokenSymbol: string
   readonly isLayer1: boolean
+  readonly isL1: boolean
   readonly nativeBridgeUrl: string | undefined
   readonly waitConfirmations?: number
   readonly explorerUrl: string
@@ -36,8 +40,10 @@ class Network {
     this.rpcUrl = props.rpcUrl
     this.provider = getProvider(props.rpcUrl)
     this.networkId = props.networkId
+    this.chainId = props.networkId
     this.nativeTokenSymbol = props.nativeTokenSymbol
     this.isLayer1 = props.isLayer1 ? props.isLayer1 : false
+    this.isL1 = this.isLayer1
     this.nativeBridgeUrl = props.nativeBridgeUrl
     this.waitConfirmations = props.waitConfirmations
     this.explorerUrl = props.explorerUrl

--- a/packages/frontend/src/pages/Stats/DebitWindowStats.tsx
+++ b/packages/frontend/src/pages/Stats/DebitWindowStats.tsx
@@ -5,7 +5,6 @@ import { Div, Icon } from 'src/components/ui'
 import { CellWrapper, RightAlignedValue, SortableTable } from 'src/components/Table'
 
 export const populateDebitWindowStats = (item: any, bonderStats, i) => {
-  console.log(`item:`, item)
   return {
     token: item.token.imageUrl,
     slot0: item.amountBonded[0],

--- a/packages/frontend/src/pages/Stats/PendingAmountStats.tsx
+++ b/packages/frontend/src/pages/Stats/PendingAmountStats.tsx
@@ -50,35 +50,18 @@ const PendingAmountStats: FC = () => {
             accessor: 'pendingAmount',
             Cell: ({ cell }) => (
               <CellWrapper cell={cell} end>
-                <Icon mr={1} src={cell.row.values.token} />
+                <Icon mr={1} src={cell.row.original.token} />
                 {commafy(cell.value)}
               </CellWrapper>
             ),
-          },
-          {
-            Header: 'Token Decimals',
-            accessor: 'tokenDecimals',
-            Cell: props => {
-              props.setHiddenColumns('tokenDecimals')
-              return <Div>_</Div>
-            },
           },
           {
             Header: 'Available Liquidity',
             accessor: 'availableLiquidity',
             Cell: ({ cell }) => (
               <CellWrapper cell={cell} end>
-                <Icon mr={1} src={cell.row.values.token} />
+                <Icon mr={1} src={cell.row.original.token} />
                 {commafy(cell.value)}
-              </CellWrapper>
-            ),
-          },
-          {
-            Header: 'Token',
-            accessor: 'token',
-            Cell: ({ cell }) => (
-              <CellWrapper cell={cell}>
-                <Icon src={cell.value} />
               </CellWrapper>
             ),
           },

--- a/packages/frontend/src/pages/Stats/PoolStats.tsx
+++ b/packages/frontend/src/pages/Stats/PoolStats.tsx
@@ -55,22 +55,16 @@ const PoolStats: FC = () => {
             ),
           },
           {
-            Header: 'Token Symbol',
-            accessor: 'tokenSymbol',
-            Cell: props => {
-              props.setHiddenColumns('tokenSymbol')
-              return <Div>_</Div>
-            },
-          },
-          {
             Header: 'Ratio',
             accessor: 'ratio',
-            Cell: ({ cell }) => (
-              <CellWrapper cell={cell}>
-                <Icon mr={1} src={cell.row.values.tokenSymbol} />
-                <Div justifySelf="right">{cell.value}</Div>
-              </CellWrapper>
-            ),
+            Cell: ({ cell, ...rest }) => {
+              return (
+                <CellWrapper cell={cell}>
+                  <Icon mr={1} src={cell.row.original.tokenSymbol} />
+                  <Div justifySelf="right">{cell.value}</Div>
+                </CellWrapper>
+              )
+            },
           },
         ],
       },

--- a/packages/frontend/yarn.lock
+++ b/packages/frontend/yarn.lock
@@ -3401,6 +3401,11 @@
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
   integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
 
+"@ethersproject/logger@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz#d7db1bfcc22fd2e4ab574cba0bb6ad779a9a3e7a"
+  integrity sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==
+
 "@ethersproject/networks@5.5.1", "@ethersproject/networks@^5.5.0":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.5.1.tgz#b7f7b9fb88dec1ea48f739b7fb9621311aa8ce6c"
@@ -3422,6 +3427,13 @@
   integrity sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==
   dependencies:
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/properties@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz#38904651713bc6bdd5bdd1b0a4287ecda920fa04"
+  integrity sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/providers@5.5.1", "@ethersproject/providers@^5.4.5":
   version "5.5.1"
@@ -3652,13 +3664,14 @@
   dependencies:
     ethers "^5.5.1"
 
-"@hop-protocol/sdk@0.0.1-beta.302":
-  version "0.0.1-beta.302"
-  resolved "https://registry.npmjs.org/@hop-protocol/sdk/-/sdk-0.0.1-beta.302.tgz#faa60ca50ef4b703752807d821b8b9c92406ee7f"
-  integrity sha512-hMYnBN2SysvKkvJtr5yvMT3hyHgNpBWpZUvCtp49b+J0Qlv/FGzWk7t0s3p0XCXEbKlMgsUSOWVckJnVPy4tvA==
+"@hop-protocol/sdk@0.0.1-beta.310":
+  version "0.0.1-beta.310"
+  resolved "https://registry.npmjs.org/@hop-protocol/sdk/-/sdk-0.0.1-beta.310.tgz#980ab48d7655b178b393de629211d6c8edd9d1e8"
+  integrity sha512-zbtNaoWSAt7PoAn4hUFFDHuUV/1hJjAXVAt5rvu3EKvFTpjwGukqNGSvudpBjLOzY0RGIchZmR4VqwV72Lpi6A==
   dependencies:
     "@eth-optimism/contracts" "^0.5.2"
     "@ethersproject/abi" "^5.4.0"
+    "@ethersproject/properties" "^5.6.0"
     "@hop-protocol/core" "0.0.1-beta.62"
     "@maticnetwork/maticjs" "^2.0.38"
     dotenv "^8.2.0"
@@ -5786,6 +5799,13 @@
   integrity sha512-RNSXOyb3VyRs/EOGmjBhhGKTbnN6fHWvy5FNLzWfOWOGjgVUKqJZXfpKzLmgoU8h6Hj8mpALj/mbXQASOb92wQ==
   dependencies:
     "@types/history" "*"
+    "@types/react" "*"
+
+"@types/react-table@^7.7.10":
+  version "7.7.10"
+  resolved "https://registry.npmjs.org/@types/react-table/-/react-table-7.7.10.tgz#ca8bb5420bfeae964ff61682f31f1cadfcfee726"
+  integrity sha512-yt7FHv/2cFsucStSWLBOB3OmsRZF08DvVHzz8Zg41B4tzRL6pQ+5VYvmhaR1dKS//tDG4UOJ1RQJPEINHYoRtg==
+  dependencies:
     "@types/react" "*"
 
 "@types/react-transition-group@^4.2.0":
@@ -20423,7 +20443,7 @@ react-scripts@^4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
-react-table@^7.7.0:
+react-table@^7.7.10:
   version "7.7.0"
   resolved "https://registry.npmjs.org/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
   integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==

--- a/packages/sdk/src/Base.ts
+++ b/packages/sdk/src/Base.ts
@@ -7,7 +7,7 @@ import { ArbitrumGlobalInbox } from '@hop-protocol/core/contracts/ArbitrumGlobal
 import { ArbitrumGlobalInbox__factory } from '@hop-protocol/core/contracts/factories/ArbitrumGlobalInbox__factory'
 import { BigNumber, BigNumberish, Signer, constants, providers } from 'ethers'
 import { Chain, Token as TokenModel } from './models'
-import { ChainSlug, Errors, MinPolygonGasPrice, NetworkSlug } from './constants'
+import { CanonicalToken, ChainSlug, Errors, MinPolygonGasPrice, NetworkSlug } from './constants'
 import { L1OptimismTokenBridge } from '@hop-protocol/core/contracts/L1OptimismTokenBridge'
 import { L1OptimismTokenBridge__factory } from '@hop-protocol/core/contracts/factories/L1OptimismTokenBridge__factory'
 import { L1PolygonPosRootChainManager } from '@hop-protocol/core/contracts/L1PolygonPosRootChainManager'
@@ -549,12 +549,22 @@ class Base {
 
   getSupportedAssets () {
     const supported : any = {}
+
+    const unsupportedAssets: any = {
+      optimism: CanonicalToken.MATIC,
+      arbitrum: CanonicalToken.MATIC,
+    }
+
     for (const token in this.addresses) {
       for (const chain in this.addresses[token]) {
         if (!supported[chain]) {
           supported[chain] = {}
         }
-        supported[chain][token] = true
+        if (chain in unsupportedAssets && unsupportedAssets[chain] === token) {
+          supported[chain][token] = false
+        } else {
+          supported[chain][token] = true
+        }
       }
     }
     return supported

--- a/packages/sdk/src/Base.ts
+++ b/packages/sdk/src/Base.ts
@@ -550,21 +550,12 @@ class Base {
   getSupportedAssets () {
     const supported : any = {}
 
-    const unsupportedAssets: any = {
-      optimism: CanonicalToken.MATIC,
-      arbitrum: CanonicalToken.MATIC,
-    }
-
     for (const token in this.addresses) {
       for (const chain in this.addresses[token]) {
         if (!supported[chain]) {
           supported[chain] = {}
         }
-        if (chain in unsupportedAssets && unsupportedAssets[chain] === token) {
-          supported[chain][token] = false
-        } else {
-          supported[chain][token] = true
-        }
+        supported[chain][token] = true
       }
     }
     return supported

--- a/packages/sdk/src/config/metadata.ts
+++ b/packages/sdk/src/config/metadata.ts
@@ -5,33 +5,38 @@ export const metadata: any = {
     kovan: hopMetadata.kovan.tokens,
     goerli: hopMetadata.goerli.tokens,
     mainnet: hopMetadata.mainnet.tokens,
-    staging: hopMetadata.mainnet.tokens
+    staging: hopMetadata.mainnet.tokens,
   },
   networks: {
     ethereum: {
       name: 'Ethereum',
       isLayer1: true,
-      nativeTokenSymbol: 'ETH'
+      nativeTokenSymbol: 'ETH',
+      chainId: 1,
     },
     arbitrum: {
       name: 'Arbitrum',
       isLayer1: false,
-      nativeTokenSymbol: 'ETH'
+      nativeTokenSymbol: 'ETH',
+      chainId: 42161,
     },
     optimism: {
       name: 'Optimism',
       isLayer1: false,
-      nativeTokenSymbol: 'ETH'
+      nativeTokenSymbol: 'ETH',
+      chainId: 10,
     },
     gnosis: {
       name: 'Gnosis',
       isLayer1: false,
-      nativeTokenSymbol: 'XDAI'
+      nativeTokenSymbol: 'XDAI',
+      chainId: 100,
     },
     polygon: {
       name: 'Polygon',
       isLayer1: false,
-      nativeTokenSymbol: 'MATIC'
-    }
-  }
+      nativeTokenSymbol: 'MATIC',
+      chainId: 137,
+    },
+  },
 }

--- a/packages/sdk/src/config/metadata.ts
+++ b/packages/sdk/src/config/metadata.ts
@@ -12,31 +12,26 @@ export const metadata: any = {
       name: 'Ethereum',
       isLayer1: true,
       nativeTokenSymbol: 'ETH',
-      chainId: 1,
     },
     arbitrum: {
       name: 'Arbitrum',
       isLayer1: false,
       nativeTokenSymbol: 'ETH',
-      chainId: 42161,
     },
     optimism: {
       name: 'Optimism',
       isLayer1: false,
       nativeTokenSymbol: 'ETH',
-      chainId: 10,
     },
     gnosis: {
       name: 'Gnosis',
       isLayer1: false,
       nativeTokenSymbol: 'XDAI',
-      chainId: 100,
     },
     polygon: {
       name: 'Polygon',
       isLayer1: false,
       nativeTokenSymbol: 'MATIC',
-      chainId: 137,
     },
   },
 }

--- a/packages/sdk/src/models/Chain.ts
+++ b/packages/sdk/src/models/Chain.ts
@@ -12,11 +12,11 @@ class Chain {
   isL1: boolean = false
   nativeTokenSymbol: string
 
-  static Ethereum = newChain(ChainSlug.Ethereum)
-  static Optimism = newChain(ChainSlug.Optimism)
-  static Arbitrum = newChain(ChainSlug.Arbitrum)
-  static Gnosis = newChain(ChainSlug.Gnosis)
-  static Polygon = newChain(ChainSlug.Polygon)
+  static Ethereum = newChain(ChainSlug.Ethereum, metadata.networks.ethereum.chainId)
+  static Optimism = newChain(ChainSlug.Optimism, metadata.networks.optimism.chainId)
+  static Arbitrum = newChain(ChainSlug.Arbitrum, metadata.networks.arbitrum.chainId)
+  static Gnosis = newChain(ChainSlug.Gnosis, metadata.networks.gnosis.chainId)
+  static Polygon = newChain(ChainSlug.Polygon, metadata.networks.polygon.chainId)
 
   static fromSlug (slug: Slug | string) {
     if (slug === 'xdai') {
@@ -27,7 +27,7 @@ class Chain {
     return newChain(slug)
   }
 
-  constructor (name: ChainName | string, chainId?: number | string, provider?: Provider) {
+  constructor (name: ChainName | string, chainId?: number, provider?: Provider) {
     this.name = name
     this.slug = (name || '').trim().toLowerCase()
     if (
@@ -41,7 +41,7 @@ class Chain {
       this.slug = ChainSlug.Ethereum
     }
     if (chainId) {
-      this.chainId = Number(chainId)
+      this.chainId = chainId
     }
     if (provider) {
       this.provider = provider
@@ -59,7 +59,7 @@ class Chain {
   }
 }
 
-function newChain (chain: NetworkSlug | ChainSlug | string) {
+function newChain (chain: NetworkSlug | ChainSlug | string, chainId?: number) {
   if (
     chain === NetworkSlug.Mainnet ||
     chain === NetworkSlug.Staging ||
@@ -71,7 +71,7 @@ function newChain (chain: NetworkSlug | ChainSlug | string) {
   if (!metadata.networks[chain]) {
     throw new Error(`unsupported chain "${chain}"`)
   }
-  return new Chain(metadata.networks[chain].name)
+  return new Chain(metadata.networks[chain].name, chainId)
 }
 
 export default Chain

--- a/packages/sdk/src/models/Chain.ts
+++ b/packages/sdk/src/models/Chain.ts
@@ -1,3 +1,4 @@
+import { mainnet } from '@hop-protocol/core/networks'
 import { ChainName, ChainSlug, Errors, NetworkSlug, Slug } from '../constants'
 import { metadata } from '../config'
 import { providers } from 'ethers'
@@ -12,11 +13,12 @@ class Chain {
   isL1: boolean = false
   nativeTokenSymbol: string
 
-  static Ethereum = newChain(ChainSlug.Ethereum, metadata.networks.ethereum.chainId)
-  static Optimism = newChain(ChainSlug.Optimism, metadata.networks.optimism.chainId)
-  static Arbitrum = newChain(ChainSlug.Arbitrum, metadata.networks.arbitrum.chainId)
-  static Gnosis = newChain(ChainSlug.Gnosis, metadata.networks.gnosis.chainId)
-  static Polygon = newChain(ChainSlug.Polygon, metadata.networks.polygon.chainId)
+  static Ethereum = newChain(ChainSlug.Ethereum, mainnet.ethereum.networkId)
+  static Optimism = newChain(ChainSlug.Optimism, mainnet.optimism.networkId)
+  static Arbitrum = newChain(ChainSlug.Arbitrum, mainnet.arbitrum.networkId)
+  static Gnosis = newChain(ChainSlug.Gnosis, mainnet.gnosis.networkId)
+  static Polygon = newChain(ChainSlug.Polygon, mainnet.polygon.networkId)
+
 
   static fromSlug (slug: Slug | string) {
     if (slug === 'xdai') {


### PR DESCRIPTION
this pr improves the stats page in some ways:

- data population: previously, the pending amounts stats section would intermittently not display optimism and arbitrum -> L1 rows. this is now resolved by ensuring the supported Chain models have a `chainId: number` field
- rm extraneous code
- visual design styles
- added @types/react-table
- fixed bug in `fetchPendingAmounts`: check both source and destination chains for unsupported assets