### PR TITLE
hop-node: Replace arb-ts with @arbitrum/sdk

### DIFF
--- a/packages/hop-node/package.json
+++ b/packages/hop-node/package.json
@@ -39,6 +39,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@arbitrum/sdk": "^1.1.4",
     "@aws-sdk/client-s3": "^3.33.0",
     "@eth-optimism/contracts": "^0.5.3",
     "@eth-optimism/core-utils": "^0.5.2",
@@ -66,7 +67,6 @@
     "@uniswap/v3-core": "^1.0.0",
     "@uniswap/v3-sdk": "^3.2.1",
     "@yfi/sdk": "2.0.1",
-    "arb-ts": "^0.0.39",
     "async-mutex": "^0.3.1",
     "aws-sdk": "^2.937.0",
     "bip39": "3.0.4",


### PR DESCRIPTION
- uses new [`@arbitrum/sdk`](https://github.com/OffchainLabs/arbitrum-sdk/tree/master) sdk for outgoing L2->L1 exit txs