### PR TITLE
hop-node: GasBoost: Make sure maxFeePerGas is always higher than baseFeePerGas

### DIFF
--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -418,8 +418,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
       const currentBaseFeePerGas = await this.getCurrentBaseFeePerGas()
       const maxGasPrice = this.getMaxGasPrice()
       if (maxFeePerGas.lte(currentBaseFeePerGas)) {
-        const newMaxFeePerGas = currentBaseFeePerGas.mul(2)
-        maxFeePerGas = newMaxFeePerGas
+        maxFeePerGas = currentBaseFeePerGas.mul(2)
       }
       maxFeePerGas = BNMin(maxFeePerGas, maxGasPrice)
 

--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -449,7 +449,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
 
     const priorityFeePerGasCap = this.getPriorityFeePerGasCap()
     return {
-      maxFeePerGas: gasFeeData.maxFeePerGas,
+      maxFeePerGas: BNMin(gasFeeData.maxFeePerGas!, this.getMaxGasPrice()),
       maxPriorityFeePerGas: BNMin(gasFeeData.maxPriorityFeePerGas!, priorityFeePerGasCap) // eslint-disable-line
     }
   }

--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -418,12 +418,10 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
       const currentBaseFeePerGas = await this.getCurrentBaseFeePerGas()
       const maxGasPrice = this.getMaxGasPrice()
       if (maxFeePerGas.lte(currentBaseFeePerGas)) {
-        let newMaxFeePerGas = currentBaseFeePerGas.mul(2)
-        if (newMaxFeePerGas.gt(maxGasPrice)) {
-          newMaxFeePerGas = maxGasPrice
-        }
+        const newMaxFeePerGas = currentBaseFeePerGas.mul(2)
         maxFeePerGas = newMaxFeePerGas
       }
+      maxFeePerGas = BNMin(maxFeePerGas, maxGasPrice)
 
       return {
         gasPrice: undefined,

--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -417,7 +417,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
 
       const currentBaseFeePerGas = await this.getCurrentBaseFeePerGas()
       const maxGasPrice = this.getMaxGasPrice()
-      if (maxFeePerGas.lte(currentBaseFeePerGas)) {
+      if (currentBaseFeePerGas && maxFeePerGas.lte(currentBaseFeePerGas)) {
         maxFeePerGas = currentBaseFeePerGas.mul(2)
       }
       maxFeePerGas = BNMin(maxFeePerGas, maxGasPrice)
@@ -451,9 +451,9 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     }
   }
 
-  async getCurrentBaseFeePerGas (): Promise<BigNumber> {
+  async getCurrentBaseFeePerGas (): Promise<BigNumber | null> {
     const { baseFeePerGas } = await this.signer.provider!.getBlock('latest')
-    return baseFeePerGas ?? await this.getMarketGasPrice()
+    return baseFeePerGas ?? null
   }
 
   getBoostCount (): number {


### PR DESCRIPTION
- Makes sure that baseFeePerGas is not greater than maxFeePerGas
  - if baseFeePerGas is greater than maxFeePerGas, then maxFeePerGas is baseFeePerGas*2
    - if new maxFeePerGas is greater than maxGasPrice, then maxFeePerGas is maxGasPrice