### PR TITLE
Feature/blocklist

### DIFF
--- a/packages/hop-node/src/config/config.ts
+++ b/packages/hop-node/src/config/config.ts
@@ -103,6 +103,11 @@ export type VaultChain = {
 
 export type Vault = Record<string, VaultChain>
 
+export type BlocklistConfig = {
+  path: string
+  addresses: Record<string, boolean>
+}
+
 export type Config = {
   isMainnet: boolean
   tokens: Tokens
@@ -119,6 +124,7 @@ export type Config = {
   fees: Fees
   routes: Routes
   vault: Vault
+  blocklist: BlocklistConfig
 }
 
 const networkConfigs: {[key: string]: any} = {
@@ -196,7 +202,11 @@ export const config: Config = {
   commitTransfers: {
     minThresholdAmount: {}
   },
-  vault: {}
+  vault: {},
+  blocklist: {
+    path: '',
+    addresses: {}
+  }
 }
 
 export const setConfigByNetwork = (network: string) => {
@@ -313,6 +323,10 @@ export const setConfigTokens = (tokens: Tokens) => {
 
 export const setVaultConfig = (vault: Vault) => {
   config.vault = { ...config.vault, ...vault }
+}
+
+export const setBlocklistConfig = (blocklist: BlocklistConfig) => {
+  config.blocklist = { ...config.blocklist, ...blocklist }
 }
 
 export const getBonderConfig = (tokens: Tokens) => {

--- a/packages/hop-node/src/config/fileOps.ts
+++ b/packages/hop-node/src/config/fileOps.ts
@@ -1,4 +1,5 @@
 import Logger, { setLogLevel } from 'src/logger'
+import fetch from 'node-fetch'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
@@ -244,11 +245,17 @@ export async function setGlobalConfigFromConfigFile (
       config.blocklist.addresses = {}
     }
     if (config.blocklist.path) {
-      const filepath = path.resolve(config.blocklist.path)
-      if (!fs.existsSync(filepath)) {
-        throw new Error(`blocklist filepath "${filepath}" does not exist`)
+      let data = ''
+      if (config.blocklist.path.startsWith('http')) {
+        const res = await fetch(config.blocklist.path)
+        data = await res.text()
+      } else {
+        const filepath = path.resolve(config.blocklist.path)
+        if (!fs.existsSync(filepath)) {
+          throw new Error(`blocklist filepath "${filepath}" does not exist`)
+        }
+        data = fs.readFileSync(filepath, 'utf8')
       }
-      const data = fs.readFileSync(filepath, 'utf8')
       const list = data.split('\n').filter(x => x)
       for (const address of list) {
         config.blocklist.addresses[address.toLowerCase()] = true

--- a/packages/hop-node/src/config/validation.ts
+++ b/packages/hop-node/src/config/validation.ts
@@ -47,7 +47,8 @@ export async function validateConfigFileStructure (config?: FileConfig) {
     'fees',
     'routes',
     'bonders',
-    'vault'
+    'vault',
+    'blocklist'
   ]
 
   const validWatcherKeys = [
@@ -247,6 +248,16 @@ export async function validateConfigFileStructure (config?: FileConfig) {
       }
     }
   }
+
+  if (config.blocklist) {
+    const blocklistConfig = config.blocklist as any
+    if (!(blocklistConfig instanceof Object)) {
+      throw new Error('blocklist config must be an object')
+    }
+    const validBlocklistKeys = ['path', 'addresses']
+    const keys = Object.keys(blocklistConfig)
+    validateKeys(validBlocklistKeys, keys)
+  }
 }
 
 export async function validateConfigValues (config?: Config) {
@@ -358,6 +369,12 @@ export async function validateConfigValues (config?: Config) {
           throw new Error('strategy is invalid. Valid options are: yearn, aave')
         }
       }
+    }
+  }
+
+  if (config.blocklist) {
+    if (typeof config.blocklist.path !== 'string') {
+      throw new Error('blocklist.path must be a string')
     }
   }
 }

--- a/packages/hop-node/src/db/TransfersDb.ts
+++ b/packages/hop-node/src/db/TransfersDb.ts
@@ -35,6 +35,7 @@ interface BaseTransfer {
   withdrawalBonded?: boolean
   withdrawalBondedTxHash?: string
   withdrawalBonder?: string
+  sender?: string
 }
 
 export interface Transfer extends BaseTransfer {
@@ -172,7 +173,8 @@ class SubDbIncompletes extends BaseDb {
       !item.transferSentBlockNumber ||
       (item.transferSentBlockNumber && !item.transferSentTimestamp) ||
       (item.withdrawalBondedTxHash && !item.withdrawalBonder) ||
-      (item.withdrawalBondSettledTxHash && !item.withdrawalBondSettled)
+      (item.withdrawalBondSettledTxHash && !item.withdrawalBondSettled) ||
+      (!item.sender)
       /* eslint-enable @typescript-eslint/prefer-nullish-coalescing */
     )
   }


### PR DESCRIPTION
- Adds config option to use blocklist
- Marks transfer as unbondable if sender or recipient is in blocklist
- Marks db transfer item as incomplete if `sender` is missing and populates missing `sender` by using `from` address of transfer tx

Example configs:

Using local text list of addresses

```
{
  ...
  "blocklist": {
    "path": "/tmp/ofac.txt"
  }
  ...
}
```

Using remote text list of addresses

```
{
  ...
  "blocklist": {
    "path": "https://example.com/ofac.txt"
  }
  ...
}
```

Using addresses directly in config 

```
{
  ...
  "blocklist": {
    "addresses": {
     "0x123...": true,
     "0xabc...": true
   }
  }
  ...
}
```

Using both remote and local addresses


```
{
  ...
  "blocklist": {
    "path": "https://example.com/ofac.txt",
    "addresses": {
     "0x123...": true,
     "0xabc...": true
   }
  }
  ...
}
```

