### PR TITLE
stats-worker: add mw stats

### DIFF
--- a/packages/stats-worker/src/Db.ts
+++ b/packages/stats-worker/src/Db.ts
@@ -224,6 +224,11 @@ class Db {
             'ALTER TABLE bonder_balances ADD COLUMN withdraw_event TEXT;'
           )
         }
+        if (migrations.includes(18)) {
+          this.db.run(
+            'ALTER TABLE bonder_balances ADD COLUMN arbitrum_messenger_wrapper_amount NUMERIC;'
+          )
+        }
 
         migrationRan = true
       }

--- a/packages/stats-worker/src/Db.ts
+++ b/packages/stats-worker/src/Db.ts
@@ -84,7 +84,8 @@ class Db {
           restaked_eth_amount NUMERIC,
           initial_eth_amount NUMERIC,
           initial_matic_amount NUMERIC,
-          initial_xdai_amount NUMERIC
+          initial_xdai_amount NUMERIC,
+          arbitrum_messenger_wrapper_amount NUMERIC
       )`)
       if (argv.resetBonderFeesDb) {
         this.db.run(`DROP TABLE IF EXISTS bonder_fees`)
@@ -348,10 +349,11 @@ class Db {
     initialEthAmount: number | null = null,
     initialMaticAmount: number | null = null,
     initialxDaiAmount: number | null = null,
-    withdrawEvent: number | null = null
+    withdrawEvent: number | null = null,
+    arbitrumMessengerWrapperAmount: number = 0
   ) {
     const stmt = this.db.prepare(
-      'INSERT OR REPLACE INTO bonder_balances VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+      'INSERT OR REPLACE INTO bonder_balances VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
     )
     stmt.run(
       uuid(),
@@ -398,7 +400,8 @@ class Db {
       initialEthAmount,
       initialMaticAmount,
       initialxDaiAmount,
-      withdrawEvent
+      withdrawEvent,
+      arbitrumMessengerWrapperAmount
     )
     stmt.finalize()
   }


### PR DESCRIPTION
Adds the Arbitrum messenger wrapper (L1) balance.

Mostly curious about the DB:

* Is adding the additional `?` to the `INSERT OR REPLACE INTO bonder_balances VALUES` correct?
* Should anything be added to the migrations to reflect this update? For example:

```
if (migrations.includes(x)) {
  this.db.run(
    'ALTER TABLE bonder_balances ADD COLUMN arbitrum_messneger_wrapper_ammountt TEXT;'
  )
}
```