### PR TITLE
hop-node: update rebroadcast logic

### DIFF
--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -579,11 +579,9 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     this.maxRebroadcastIndexReached = true
     this.clearInflightTxs()
     this.emit(State.Error)
-    const warnMsg = `max rebroadcast index reached. cannot rebroadcast.`
-   const errMsg = `max rebroadcast index reached. cannot rebroadcast.`
+    const errMsg = `max rebroadcast index reached. cannot rebroadcast.`
     this.notifier.error(errMsg, { channel: gasBoostErrorSlackChannel })
     this.logger.error(errMsg)
-    this.logger.warn(warnMsg)
   }
 
   private async getReceipt (txHash: string) {

--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -580,7 +580,9 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     this.clearInflightTxs()
     this.emit(State.Error)
     const warnMsg = `max rebroadcast index reached. cannot rebroadcast.`
-    this.notifier.warn(warnMsg, { channel: gasBoostWarnSlackChannel })
+   const errMsg = `max rebroadcast index reached. cannot rebroadcast.`
+    this.notifier.error(errMsg, { channel: gasBoostErrorSlackChannel })
+    this.logger.error(errMsg)
     this.logger.warn(warnMsg)
   }
 


### PR DESCRIPTION
Resolves two issues:
* Previously, a tx that was re-broadcasted was retried every poll because `item!.sentAt = Date.now()` was being set _after_ the tx that was failing (because of an `already known` error). This was causing a ton of RPC usage and overhead. This PR moves the state setting logic to occur prior to the tx so that the result of the tx does not matter
* Introduce the concept of max reboosts. If a tx doesn't get picked up after max gas AND another ~30 mins, there is something wrong and should be handled accordingly