### PR TITLE
add white-space nowrap to styledbutton

### DIFF
--- a/packages/frontend/src/components/buttons/StyledButton.tsx
+++ b/packages/frontend/src/components/buttons/StyledButton.tsx
@@ -22,6 +22,7 @@ type StylishButtonProps = ComposedStyleProps & StyleProps
 export const StyledButton = styled(Button)<StylishButtonProps>`
   text-transform: 'none';
   transition: 'all 0.15s ease-out';
+  white-space: nowrap;
 
   ${({ large }: any) => {
     if (large) {


### PR DESCRIPTION
styled button wraps and overflows its container, screenshot included. (ubuntu, firefox, md size window)

added white-space: nowrap; to styledbutton component to prevent the overflow

![Screenshot from 2022-12-20 17-24-04](https://user-images.githubusercontent.com/80549215/208810168-4aa153ce-95e4-498e-8df6-503ef048f696.png)
