### PR TITLE
sdk: PriceFeed: Fetch prices from S3 json file, fallback to apis

### DIFF
--- a/packages/sdk/src/HopBridge.ts
+++ b/packages/sdk/src/HopBridge.ts
@@ -9,7 +9,7 @@ import { L2_AmmWrapper__factory } from '@hop-protocol/core/contracts/factories/g
 import { L2_Bridge } from '@hop-protocol/core/contracts/generated/L2_Bridge'
 import { L2_Bridge__factory } from '@hop-protocol/core/contracts/factories/generated/L2_Bridge__factory'
 
-import { ApiKeys, PriceFeed } from './priceFeed'
+import { ApiKeys, PriceFeedFromS3 } from './priceFeed'
 import {
   BigNumber,
   BigNumberish,
@@ -131,7 +131,7 @@ class HopBridge extends Base {
   /** Default deadline for transfers */
   public defaultDeadlineMinutes = 7 * 24 * 60 // 1 week
 
-  priceFeed: PriceFeed
+  priceFeed: PriceFeedFromS3
   priceFeedApiKeys: ApiKeys | null = null
   doesUseAmm: boolean
 
@@ -177,7 +177,7 @@ class HopBridge extends Base {
       throw new Error('token is required')
     }
 
-    this.priceFeed = new PriceFeed(this.priceFeedApiKeys)
+    this.priceFeed = new PriceFeedFromS3(this.priceFeedApiKeys)
     this.doesUseAmm = this.tokenSymbol !== CanonicalToken.HOP
     if (this.network === NetworkSlug.Goerli) {
       this.doesUseAmm = !(

--- a/packages/sdk/src/priceFeed/PriceFeed.ts
+++ b/packages/sdk/src/priceFeed/PriceFeed.ts
@@ -47,6 +47,10 @@ export class PriceFeed {
     this.services = [new CoinGecko(this.apiKeys?.coingecko), new Coinbase(), new Coinpaprika(), new CoinCodex()]
   }
 
+  prependService (service: Service) {
+    this.services.unshift(service)
+  }
+
   async getPriceByTokenSymbol (tokenSymbol: string) {
     if (this.aliases[tokenSymbol]) {
       tokenSymbol = this.aliases[tokenSymbol]

--- a/packages/sdk/src/priceFeed/PriceFeedFromS3.ts
+++ b/packages/sdk/src/priceFeed/PriceFeedFromS3.ts
@@ -1,0 +1,19 @@
+import { ApiKeys, PriceFeed } from './PriceFeed'
+import { S3 } from './S3'
+
+export class PriceFeedFromS3 {
+  priceFeed: PriceFeed
+
+  constructor (apiKeysMap: ApiKeys = {}) {
+    this.priceFeed = new PriceFeed(apiKeysMap)
+    this.priceFeed.prependService(new S3())
+  }
+
+  setApiKeys (apiKeysMap: ApiKeys = {}) {
+    this.priceFeed.setApiKeys(apiKeysMap)
+  }
+
+  async getPriceByTokenSymbol (tokenSymbol: string) {
+    return this.priceFeed.getPriceByTokenSymbol(tokenSymbol)
+  }
+}

--- a/packages/sdk/src/priceFeed/S3.ts
+++ b/packages/sdk/src/priceFeed/S3.ts
@@ -1,0 +1,20 @@
+import { fetchJsonOrThrow } from '../utils/fetchJsonOrThrow'
+
+export class S3 {
+  private readonly url: string = 'https://assets.hop.exchange/token-prices.json'
+  stalenessLimitMs: number = 10 * 60 * 1000
+
+  public getPriceByTokenSymbol = async (symbol: string): Promise<number> => {
+    const data = await fetchJsonOrThrow(this.url)
+    for (const key in data.prices) {
+      if (key.toUpperCase() === symbol.toUpperCase()) {
+        const isOk = data.timestamp > Date.now() - this.stalenessLimitMs
+        if (isOk) {
+          return data.prices[key]
+        }
+      }
+    }
+
+    return null
+  }
+}

--- a/packages/sdk/src/priceFeed/index.ts
+++ b/packages/sdk/src/priceFeed/index.ts
@@ -1,1 +1,2 @@
 export { default as PriceFeed, ApiKeys } from './PriceFeed'
+export { PriceFeedFromS3 } from './PriceFeedFromS3'

--- a/packages/sdk/test/priceFeed/priceFeed.test.ts
+++ b/packages/sdk/test/priceFeed/priceFeed.test.ts
@@ -3,6 +3,7 @@ import { CoinGecko } from '../../src/priceFeed/CoinGecko'
 import { Coinbase } from '../../src/priceFeed/Coinbase'
 import { Coinpaprika } from '../../src/priceFeed/Coinpaprika'
 import { Hop } from '../../src/index'
+import { S3 } from '../../src/priceFeed/S3'
 
 // skipped since it might trigger rate limits and cause test suite to fail
 describe.skip('PriceFeed', () => {
@@ -356,5 +357,71 @@ describe.skip('PriceFeed', () => {
       console.log('TUSD', price)
       expect(price).toBeGreaterThan(0)
     })
+  })
+})
+
+describe.only('PriceFeed - S3', () => {
+  it('should return USDC price', async () => {
+    const priceFeed = new S3()
+    const price = await priceFeed.getPriceByTokenSymbol('USDC')
+    console.log(price)
+    expect(price).toBeGreaterThan(0)
+    expect(price).toBeLessThan(2)
+  }, 60 * 1000)
+  it('should return ETH price', async () => {
+    const priceFeed = new S3()
+    const price = await priceFeed.getPriceByTokenSymbol('ETH')
+    console.log(price)
+    expect(price).toBeGreaterThan(0)
+    expect(price).toBeLessThan(10000)
+  }, 60 * 1000)
+  it('should return DAI price', async () => {
+    const priceFeed = new S3()
+    const price = await priceFeed.getPriceByTokenSymbol('DAI')
+    console.log(price)
+    expect(price).toBeGreaterThan(0)
+    expect(price).toBeLessThan(2)
+  }, 60 * 1000)
+  it('should return USDT price', async () => {
+    const priceFeed = new S3()
+    const price = await priceFeed.getPriceByTokenSymbol('USDT')
+    console.log(price)
+    expect(price).toBeGreaterThan(0)
+    expect(price).toBeLessThan(2)
+  }, 60 * 1000)
+  it('should return MATIC price', async () => {
+    const priceFeed = new CoinGecko()
+    const price = await priceFeed.getPriceByTokenSymbol('MATIC')
+    console.log(price)
+    expect(price).toBeGreaterThan(0)
+    expect(price).toBeLessThan(10)
+  }, 60 * 1000)
+  it('should return HOP price', async () => {
+    const priceFeed = new S3()
+    const price = await priceFeed.getPriceByTokenSymbol('HOP')
+    console.log(price)
+    expect(price).toBeGreaterThan(0)
+    expect(price).toBeLessThan(50)
+  }, 60 * 1000)
+  it('should return SNX price', async () => {
+    const priceFeed = new S3()
+    const price = await priceFeed.getPriceByTokenSymbol('SNX')
+    console.log(price)
+    expect(price).toBeGreaterThan(0)
+    expect(price).toBeLessThan(50)
+  }, 60 * 1000)
+  it('should return sUSD price', async () => {
+    const priceFeed = new S3()
+    const price = await priceFeed.getPriceByTokenSymbol('sUSD')
+    console.log(price)
+    expect(price).toBeGreaterThan(0)
+    expect(price).toBeLessThan(2)
+  }, 60 * 1000)
+  it('should return rETH price', async () => {
+    const priceFeed = new S3()
+    const price = await priceFeed.getPriceByTokenSymbol('rETH')
+    console.log(price)
+    expect(price).toBeGreaterThan(0)
+    expect(price).toBeLessThan(10000)
   })
 })


### PR DESCRIPTION
Stats worker is writing to json file

```sh
curl https://assets.hop.exchange/token-prices.json | jq
```

SDK fetches data from this json file, and falls back to quering apis if price is either missing or stale.