### PR TITLE
Feat/add exponential backoff to latent rpc

### DIFF
--- a/packages/hop-node/src/constants/constants.ts
+++ b/packages/hop-node/src/constants/constants.ts
@@ -91,6 +91,7 @@ export enum TxError {
   BonderFeeTooLow = 'BONDER_FEE_TOO_LOW',
   RelayerFeeTooLow = 'RELAYER_FEE_TOO_LOW',
   NotEnoughLiquidity = 'NOT_ENOUGH_LIQUIDITY',
+  RedundantRpcOutOfSync = 'REDUNDANT_RPC_OUT_OF_SYNC',
 }
 
 export const MaxPriorityFeeConfidenceLevel = 95

--- a/packages/hop-node/src/db/TransfersDb.ts
+++ b/packages/hop-node/src/db/TransfersDb.ts
@@ -484,14 +484,11 @@ class TransfersDb extends BaseDb {
       let timestampOk = true
       if (item.relayAttemptedAt) {
         if (TxError.RelayerFeeTooLow === item.relayTxError) {
-          const delay = TxRetryDelayMs + ((1 << item.relayBackoffIndex!) * 60 * 1000) // eslint-disable-line
-          // TODO: use `sentTransferTimestamp` once it's added to db
-
-          // don't attempt to relay after a week
-          if (delay > OneWeekMs) {
+          const delayMs = getExponentialBackoffDelayMs(item.relayBackoffIndex!)
+          if (delayMs > OneWeekMs) {
             return false
           }
-          timestampOk = item.relayAttemptedAt + delay < Date.now()
+          timestampOk = item.relayAttemptedAt + delayMs < Date.now()
         } else {
           timestampOk = item.relayAttemptedAt + TxRetryDelayMs < Date.now()
         }

--- a/packages/hop-node/src/utils/getExponentialBackoffDelayMs.ts
+++ b/packages/hop-node/src/utils/getExponentialBackoffDelayMs.ts
@@ -1,0 +1,5 @@
+const getExponentialBackoffDelayMs = (backoffIndex: number): number => {
+  return (1 << backoffIndex) * 60 * 1000 // eslint-disable
+}
+
+export default getExponentialBackoffDelayMs 

--- a/packages/hop-node/src/utils/getExponentialBackoffDelayMs.ts
+++ b/packages/hop-node/src/utils/getExponentialBackoffDelayMs.ts
@@ -2,4 +2,4 @@ const getExponentialBackoffDelayMs = (backoffIndex: number): number => {
   return (1 << backoffIndex) * 60 * 1000 // eslint-disable
 }
 
-export default getExponentialBackoffDelayMs 
+export default getExponentialBackoffDelayMs


### PR DESCRIPTION
* Adds exponential retry logic when a redundant RPC provider is either out of sync or offline for an extended period of time. Note, this implementation is completely separate from our custom provider that retries 5 times. If the `const redundantBlockNumber = await redundantProvider.getBlockNumber()` call fails, it will retry up to 5 times. However, this PR handles the case where that call succeeds _but_ the chain isn't yet up-to-date.
* Removes the `TxRetryDelayMs` when exponentially backing off (i.e. if the tx is backing off, the second tx will be attempted now after 2 minutes instead of 1hr and 2 minutes). With the hindsight of what we have seen in practice, I do not believe having this additional `TxRetryDelayMs` has provided any benefit. If a fee is genuinely too low, it will never be bonded anyway. If it is barely too low, now it will be retried at a faster cadence and possibly result in a quicker bond. Finally, if the bonder backsoff now because of the redundant RPC check, it is likely that the redundant RPC will be synced w/in a few seconds, so waiting an hour would be inneficient.