### PR TITLE
Feat/gasboost tx updates

### DIFF
--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -835,7 +835,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
           throw new EstimateGasError('EstimateGasError')
         }
 
-        const isRetryableError = (isAlreadyKnown || isFeeTooLow || serverError)
+        const isRetryableError = isAlreadyKnown || isFeeTooLow || serverError
         if (isRetryableError) {
           if (i < this.maxRetryIndex) {
             continue

--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -342,7 +342,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
   }
 
   async send () {
-    const _timeId = `GasBoostTransaction send getBumpedGasFeeData elapsed ${this.logId} `
+    const _timeId = `GasBoostTransaction send getBumpedGasFeeData elapsed ${this.logId} ${Date.now()}`
     console.time(_timeId)
     let gasFeeData = await this.getBumpedGasFeeData(this.initialTxGasPriceMultiplier)
     console.timeEnd(_timeId)
@@ -768,7 +768,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
           }
           if (shouldCheck) {
             this.logger.debug(`tx index ${i}: checking for enough funds`)
-            const _timeId = `GasBoostTransaction _sendTransaction checkHasEnoughFunds elapsed ${this.logId} ${i} `
+            const _timeId = `GasBoostTransaction _sendTransaction checkHasEnoughFunds elapsed ${this.logId} ${i} (${Date.now()})`
             console.time(_timeId)
             enoughFundsCheckCache[this.chainSlug] = Date.now()
             await this.checkHasEnoughFunds(payload, gasFeeData)
@@ -778,7 +778,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
 
         this.logger.debug(`tx index ${i}: sending transaction`)
 
-        const _timeId = `GasBoostTransaction signer.sendTransaction elapsed ${this.logId} ${i} `
+        const _timeId = `GasBoostTransaction signer.sendTransaction elapsed ${this.logId} ${i} (${Date.now()})`
         // await here is intentional to catch error below
         console.time(_timeId)
         const tx = await this.signer.sendTransaction(payload)
@@ -822,7 +822,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     let gasLimit
     let ethBalance
 
-    const _timeId1 = `GasBoostTransaction checkHasEnoughFunds estimateGas elapsed ${this.logId} `
+    const _timeId1 = `GasBoostTransaction checkHasEnoughFunds estimateGas elapsed ${this.logId} (${Date.now()})`
     console.time(_timeId1)
     try {
       gasLimit = await this.signer.estimateGas(payload)
@@ -831,7 +831,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     }
     console.timeEnd(_timeId1)
 
-    const _timeId2 = `GasBoostTransaction checkHasEnoughFunds getBalance elapsed ${this.logId} `
+    const _timeId2 = `GasBoostTransaction checkHasEnoughFunds getBalance elapsed ${this.logId} (${Date.now()})`
     console.time(_timeId2)
     try {
       ethBalance = await this.signer.getBalance()

--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -443,9 +443,6 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
 
   async getBumpedGasPrice (multiplier: number = this.gasPriceMultiplier): Promise<BigNumber> {
     const marketGasPrice = await this.getMarketGasPrice()
-    if (!this.isChainGasFeeBumpable()) {
-      return marketGasPrice
-    }
     const prevGasPrice = this.gasPrice ?? marketGasPrice
     const bumpedGasPrice = getBumpedGasPrice(prevGasPrice, multiplier)
     if (!this.compareMarketGasPrice) {
@@ -456,9 +453,6 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
 
   async getBumpedMaxPriorityFeePerGas (multiplier: number = this.gasPriceMultiplier): Promise<BigNumber> {
     const marketMaxPriorityFeePerGas = await this.getMarketMaxPriorityFeePerGas()
-    if (!this.isChainGasFeeBumpable()) {
-      return marketMaxPriorityFeePerGas
-    }
     const prevMaxPriorityFeePerGas = this.maxPriorityFeePerGas ?? marketMaxPriorityFeePerGas
     const minPriorityFeePerGas = this.getMinPriorityFeePerGas()
     this.logger.debug(`getting bumped maxPriorityFeePerGas. this.maxPriorityFeePerGas: ${this.maxPriorityFeePerGas?.toString()}, marketMaxPriorityFeePerGas: ${marketMaxPriorityFeePerGas.toString()}`)
@@ -944,15 +938,6 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     const format = (value?: BigNumber) => (value != null) ? this.formatGwei(value) : null
     const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } = gasFeeData
     return `gasPrice: ${format(gasPrice)}, maxFeePerGas: ${format(maxFeePerGas)}, maxPriorityFeePerGas: ${format(maxPriorityFeePerGas)}`
-  }
-
-  isChainGasFeeBumpable () {
-    // Optimism gasPrice must be constant; shouldn't be bumped
-    if (this.chainSlug === Chain.Optimism) {
-      return false
-    }
-
-    return true
   }
 
   // explainer: https://stackoverflow.com/q/35185749/1439168

--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -703,10 +703,10 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
     const maxGasPrice = this.getMaxGasPrice()
     const priorityFeePerGasCap = this.getPriorityFeePerGasCap()
 
-    // don't boost if suggested gas is over max
-    const isGasPriceMaxReached = gasFeeData.gasPrice?.gt(maxGasPrice)
-    const isMaxFeePerGasReached = gasFeeData.maxFeePerGas?.gt(maxGasPrice)
-    const isMaxPriorityFeePerGasReached = gasFeeData.maxPriorityFeePerGas?.gt(priorityFeePerGasCap)
+    // don't boost if suggested gas is equal to or over max
+    const isGasPriceMaxReached = gasFeeData.gasPrice?.gte(maxGasPrice)
+    const isMaxFeePerGasReached = gasFeeData.maxFeePerGas?.gte(maxGasPrice)
+    const isMaxPriorityFeePerGasReached = gasFeeData.maxPriorityFeePerGas?.gte(priorityFeePerGasCap)
     let isMaxReached = isGasPriceMaxReached ?? isMaxFeePerGasReached
 
     this.logger.debug(`isGasPriceMaxReached: ${isGasPriceMaxReached}, gasFeeData.gasPrice: ${gasFeeData?.gasPrice}, maxGasPrice: ${maxGasPrice}`)


### PR DESCRIPTION
* Fixes bug that infinitely loops and attempts transactions if the initial tx has gas data greater than the max cap. In the current logic, if a tx is created when the network's gas is greater than the max the bonder is willing to spend, the gas data for the tx will equal the max (i.e. 500 gwei). If the tx is not included in a block, the tx will be boosted. In `boost()`, `isMaxReached` checks that the gas data is `gt` the max gas data. However, in this case, the gas data is equal to the max gas data, so `isMaxReached` is never set to `true` and the tx gets retried 10 times and eventually throws. That throw is not handled in the poller, so the tx is attempted again 10 more times, and the rest repeats.
  * Fix 1: When calling `boost()`, check for `gte` instead of `gt`
  * Fix 2: Explicitly handle the err case when max index is reached. Break out of the poller in this case.
  * Example error log from old code: `tx index 1 error: replacement fee too low [ See: https://links.ethers.org/v5-errors-REPLACEMENT_UNDERPRICED ]..."body": "{\"jsonrpc\":\"2.0\",\"id\":187499,\"error\":{\"code\":-32000,\"message\":\"replacement transaction underpriced\"}}",`
* Adds a unique timestamp to `console.time()`. Sometimes we would call `console.time()`, but error out before calling `console.timeEnd()` for that ID. If we loop again, there is no uniqueness, so the logs have an error: `(node:1) Warning: Label 'GasBoostTransaction signer.sendTransaction elapsed ethereum id: 5ebb1dd5-b62a-4fcd-b0e0-5bec648de1ca transferId: 0x1718f96dd5cec4c673274f0021cc564b11fcaab27593d432881e509491b26d95 5 ' already exists for console.time()`. This just avoids that error
* Adds redundant logs for use in future debugging