### PR TITLE
Feat/custom start block fix

### DIFF
--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -218,26 +218,19 @@ class SyncWatcher extends BaseWatcher {
 
   async syncHandler (): Promise<any> {
     const promises: Array<Promise<any>> = []
-    let startBlockNumber = this.bridge.bridgeDeployedBlockNumber
-    let useCacheKey = true
 
-    // if it is first sync upon start and
-    // custom start block was specified,
-    // then use that as initial start block
+    // Use a custom start block number on the initial sync if it is defined
+    let startBlockNumber: number = this.bridge.bridgeDeployedBlockNumber
     if (!this.isInitialSyncCompleted() && this.customStartBlockNumber) {
-      useCacheKey = false
       startBlockNumber = this.customStartBlockNumber
+
     }
 
     const getOptions = (keyName: string) => {
-      const options = {
-        cacheKey: useCacheKey ? this.cacheKey(keyName) : undefined,
+      return {
+        cacheKey: this.cacheKey(keyName),
         startBlockNumber
       }
-      if (this.syncIndex === 0) {
-        this.logger.debug(`syncing with options: ${JSON.stringify(options)}. Note: startBlockNumber is only used if latestBlockSynced for cacheKey is not set.`)
-      }
-      return options
     }
 
     const transferRootInitialEventPromises: Array<Promise<any>> = []

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -228,7 +228,7 @@ class SyncWatcher extends BaseWatcher {
 
     const getOptions = (keyName: string) => {
       return {
-        cacheKey: this.cacheKey(keyName),
+        syncCacheKey: this.syncCacheKey(keyName),
         startBlockNumber
       }
     }

--- a/packages/hop-node/src/watchers/classes/BaseWatcher.ts
+++ b/packages/hop-node/src/watchers/classes/BaseWatcher.ts
@@ -204,7 +204,7 @@ class BaseWatcher extends EventEmitter implements IBaseWatcher {
     return this.bridge.chainSlugToId(chainSlug)
   }
 
-  cacheKey (key: string) {
+  syncCacheKey (key: string) {
     return `${this.tag}:${key}`
   }
 

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -19,7 +19,7 @@ import { getContractFactory, predeploys } from '@eth-optimism/contracts'
 import { config as globalConfig } from 'src/config'
 
 export type EventsBatchOptions = {
-  cacheKey: string
+  syncCacheKey: string
   startBlockNumber: number
   endBlockNumber: number
 }
@@ -558,15 +558,16 @@ export default class Bridge extends ContractBase {
   ) {
     this.validateEventsBatchInput(options)
 
-    let cacheKey = ''
+    // A syncCacheKey should only be defined when syncing, not when calling this function outside of a sync
+    let syncCacheKey = ''
     let state: State | undefined
-    if (options.cacheKey) {
-      cacheKey = this.getCacheKeyFromKey(
+    if (options.syncCacheKey) {
+      syncCacheKey = this.getSyncCacheKeyFromKey(
         this.chainId,
         this.address,
-        options.cacheKey
+        options.syncCacheKey
       )
-      state = await this.db.syncState.getByKey(cacheKey)
+      state = await this.db.syncState.getByKey(syncCacheKey)
     }
 
     const blockValues = await this.getBlockValues(options, state)
@@ -578,7 +579,7 @@ export default class Bridge extends ContractBase {
       latestBlockInBatch
     } = blockValues
 
-    this.logger.debug(`eventsBatch cacheKey: ${cacheKey} getBlockValues: ${JSON.stringify(blockValues)}`)
+    this.logger.debug(`eventsBatch syncCacheKey: ${syncCacheKey} getBlockValues: ${JSON.stringify(blockValues)}`)
 
     let i = 0
     while (start >= earliestBlockInBatch) {
@@ -600,12 +601,13 @@ export default class Bridge extends ContractBase {
       i++
     }
 
-    // Only store latest block if a full sync is successful.
-    // Sync is complete when the start block is reached since
+    // Only store latest block if a sync is successful. Sync is complete when the start block is reached since
     // it traverses backwards from head.
-    if (cacheKey && start === earliestBlockInBatch) {
-      this.logger.debug(`eventsBatch cacheKey: ${cacheKey} syncState latestBlockInBatch: ${latestBlockInBatch}`)
-      await this.db.syncState.update(cacheKey, {
+    // NOTE: The syncCacheKey here enforces that the syncState is only updated during a sync and not when this
+    // is called for other purposes, such as looking onchain for transferIds in a root.
+    if (syncCacheKey && start === earliestBlockInBatch) {
+      this.logger.debug(`eventsBatch syncCacheKey: ${syncCacheKey} syncState latestBlockInBatch: ${latestBlockInBatch}`)
+      await this.db.syncState.update(syncCacheKey, {
         latestBlockSynced: latestBlockInBatch,
         timestamp: Date.now()
       })
@@ -673,7 +675,7 @@ export default class Bridge extends ContractBase {
     }
   }
 
-  public getCacheKeyFromKey = (
+  public getSyncCacheKeyFromKey = (
     chainId: number,
     address: string,
     key: string
@@ -691,7 +693,7 @@ export default class Bridge extends ContractBase {
   private readonly validateEventsBatchInput = (
     options: Partial<EventsBatchOptions> = {}
   ) => {
-    const { cacheKey, startBlockNumber, endBlockNumber } = options
+    const { syncCacheKey, startBlockNumber, endBlockNumber } = options
 
     const isStartAndEndBlock = startBlockNumber && endBlockNumber
     if (isStartAndEndBlock) {
@@ -707,7 +709,7 @@ export default class Bridge extends ContractBase {
         )
       }
 
-      if (cacheKey) {
+      if (syncCacheKey) {
         throw new Error(
           'A key cannot exist when a start and end block are explicitly defined'
         )

--- a/packages/hop-node/test/bridge.test.ts
+++ b/packages/hop-node/test/bridge.test.ts
@@ -70,7 +70,7 @@ describe.skip('events batch - Happy Path', () => {
         }
         count++
       },
-      { cacheKey: key }
+      { syncCacheKey: key }
     )
 
     expect(count).toBe(expectedCount)
@@ -80,8 +80,8 @@ describe.skip('events batch - Happy Path', () => {
     const key: string = 'testingKey'
     const chainId = await bridge.getChainId()
     const address = bridge.getAddress()
-    const cacheKey = bridge.getCacheKeyFromKey(chainId, address, key)
-    let state = await bridge.db.syncState.getByKey(cacheKey)
+    const syncCacheKey = bridge.getSyncCacheKeyFromKey(chainId, address, key)
+    let state = await bridge.db.syncState.getByKey(syncCacheKey)
 
     // Create entry for key if it does not exist
     if (!state) {
@@ -92,11 +92,11 @@ describe.skip('events batch - Happy Path', () => {
           expect(end).toBe(start + batchBlocks)
           count++
         },
-        { cacheKey: key }
+        { syncCacheKey: key }
       )
     }
 
-    state = await bridge.db.syncState.getByKey(cacheKey)
+    state = await bridge.db.syncState.getByKey(syncCacheKey)
     expect(state.latestBlockSynced).toBeDefined()
     expect(state.timestamp).toBeDefined()
 
@@ -109,10 +109,10 @@ describe.skip('events batch - Happy Path', () => {
         expect(index).toBe(count)
         count++
       },
-      { cacheKey: key }
+      { syncCacheKey: key }
     )
 
-    state = await bridge.db.syncState.getByKey(cacheKey)
+    state = await bridge.db.syncState.getByKey(syncCacheKey)
     expect(state.latestBlockSynced).toBeGreaterThan(latestBlockSynced)
     expect(state.timestamp).toBeGreaterThan(timestamp)
     expect(count).toBe(1)
@@ -228,7 +228,7 @@ describe.skip('events batch - Non-Happy Path', () => {
     try {
       await bridge.eventsBatch(
         async (start: number, end: number, index: number) => {},
-        { startBlockNumber, endBlockNumber, cacheKey: key }
+        { startBlockNumber, endBlockNumber, syncCacheKey: key }
       )
     } catch (err) {
       expect(err.message).toBe(

--- a/packages/hop-node/test/eventsBatch.test.ts
+++ b/packages/hop-node/test/eventsBatch.test.ts
@@ -77,7 +77,7 @@ describe.skip('eventsBatch', () => {
   )
 
   it(
-    'eventsBatch with cacheKey',
+    'eventsBatch with syncCacheKey',
     async () => {
       const { l2Bridge } = contracts.get(Token.USDC, Chain.Gnosis)
       const bridge = new Bridge(l2Bridge)
@@ -88,7 +88,7 @@ describe.skip('eventsBatch', () => {
       const maxIterations = Math.floor(totalBlocks / batchBlocks)
       const remainder = totalBlocks % batchBlocks
       const halfway = Math.floor(maxIterations / 2)
-      const cacheKey = `${Date.now()}`
+      const syncCacheKey = `${Date.now()}`
       let iterations = 0
 
       expect(batchBlocks).toBe(1000)
@@ -114,7 +114,7 @@ describe.skip('eventsBatch', () => {
           }
           return true
         },
-        { cacheKey }
+        { syncCacheKey }
       )
 
       expect(iterations).toBe(halfway)
@@ -128,7 +128,7 @@ describe.skip('eventsBatch', () => {
           }
           iterations++
         },
-        { cacheKey }
+        { syncCacheKey }
       )
 
       expect(iterations).toBeGreaterThanOrEqual(halfway + maxIterations)


### PR DESCRIPTION
1. Renames `cacheKey` to `syncCacheKey`. This is more explicit, since the `cacheKey` in this scenario should only be used when syncing. The helps avoid any confusion when calling `eventsBatch()` from outside of a sync, like when we are looking onchain for transferIds for a transfer root.
2. Fixes bug that required a new bonder to sync from `bridgeDeployedBlockNumber` if it had not synced that far before, such as a fresh DB. I believe I intentionally enforced this at the time of writing almost 2 years ago, since the bonder might need all data in order to bond a root (for example, an unpopular route might take 6+ months to form a root). I no longer believe that is required, since we [look onchain](https://github.com/hop-protocol/hop/blob/7db61596a94c5ca0d38917c8444a2356aa3b2a82/packages/hop-node/src/watchers/SyncWatcher.ts#L1311) now if transferIds are missing from the DB.

Walking through the case where the bonder did not have a DB:

* Old behavior
	* When `--sync-from-date` was defined, the initial sync would [correctly use a `startBlock`](https://github.com/hop-protocol/hop/blob/7db61596a94c5ca0d38917c8444a2356aa3b2a82/packages/hop-node/src/watchers/classes/Bridge.ts#L639-L640) that matched the sync from date. After completion of the sync, it would [**not** write to the syncState DB](https://github.com/hop-protocol/hop/blob/7db61596a94c5ca0d38917c8444a2356aa3b2a82/packages/hop-node/src/watchers/classes/Bridge.ts#L606-L612), since the `cacheKey` was [not set](https://github.com/hop-protocol/hop/blob/7db61596a94c5ca0d38917c8444a2356aa3b2a82/packages/hop-node/src/watchers/SyncWatcher.ts#L228). On the next loop, it was still considered an [initial sync](https://github.com/hop-protocol/hop/blob/7db61596a94c5ca0d38917c8444a2356aa3b2a82/packages/hop-node/src/watchers/classes/Bridge.ts#L629) in `eventsBatch()`, since we hadn't yet written to the syncState DB. However, this time, the start block was [`bridgeDeployedBlockNumber`](https://github.com/hop-protocol/hop/blob/7db61596a94c5ca0d38917c8444a2356aa3b2a82/packages/hop-node/src/watchers/SyncWatcher.ts#L221), since the first sync was completed and we are now using the `cacheKey`. This means the second sync would look all the way back to the start of the bridge.

* New behavior
	* We now always use the `cacheKey` when syncing, no matter what. Now, the same behavior happens on the first loop, except we write to the syncState DB after the initial sync. Upon second sync, the state is now [`isSync`](https://github.com/hop-protocol/hop/blob/7db61596a94c5ca0d38917c8444a2356aa3b2a82/packages/hop-node/src/watchers/classes/Bridge.ts#L630) instead of `isInitialSync`. Because of this, the syncState DB `latestBlockSynced` is used as the start instead of the bridge start block number.