### PR TITLE
hop-node: normalize default path across platforms and various tweaks

### DIFF
--- a/packages/hop-node/.dockerignore
+++ b/packages/hop-node/.dockerignore
@@ -1,3 +1,4 @@
 node_modules
 Dockerfile
 *.env
+.git

--- a/packages/hop-node/Dockerfile
+++ b/packages/hop-node/Dockerfile
@@ -15,6 +15,7 @@ RUN npm run build
 
 FROM node:14-alpine
 WORKDIR /usr/src/app
+USER node
 COPY --from=build /usr/src/app/node_modules /usr/src/app/node_modules
 COPY --from=build /usr/src/app/dist /usr/src/app/dist
 COPY --from=build /usr/src/app/bin /usr/src/app/bin

--- a/packages/hop-node/src/cli/hopNode.ts
+++ b/packages/hop-node/src/cli/hopNode.ts
@@ -1,7 +1,9 @@
+import fs from 'fs'
 import OsWatcher from 'src/watchers/OsWatcher'
 import { HealthCheckWatcher } from 'src/watchers/HealthCheckWatcher'
 import {
   bondWithdrawalBatchSize,
+  defaultConfigFilePath,
   gitRev,
   config as globalConfig,
   slackAuthToken,
@@ -52,9 +54,12 @@ async function main (source: any) {
   logger.debug('starting hop node')
   logger.debug(`git revision: ${gitRev}`)
 
-  const { config, syncFromDate, s3Upload, s3Namespace, clearDb, heapdump, healthCheckDays, healthCheckCacheFile, enabledChecks, dry: dryMode, resyncIntervalMs, arbBot: runArbBot, arbBotConfig } = source
+  let { config, syncFromDate, s3Upload, s3Namespace, clearDb, heapdump, healthCheckDays, healthCheckCacheFile, enabledChecks, dry: dryMode, resyncIntervalMs, arbBot: runArbBot, arbBotConfig } = source
   if (!config) {
-    throw new Error('config file is required')
+    if (!fs.existsSync(defaultConfigFilePath)) {
+      throw new Error(`config file not set and config file does not exist at default path ${defaultConfigFilePath}`)
+    }
+    config = JSON.parse(fs.readFileSync(defaultConfigFilePath, 'utf8'))
   }
 
   logger.warn(`dry mode: ${!!dryMode}`)

--- a/packages/hop-node/src/cli/shared/shared.ts
+++ b/packages/hop-node/src/cli/shared/shared.ts
@@ -7,6 +7,7 @@ import { Command } from 'commander'
 import {
   getAllChains,
   config as globalConfig,
+  defaultConfigFilePath,
   parseConfigFile,
   setGlobalConfigFromConfigFile,
   validateConfigFileStructure,
@@ -27,7 +28,7 @@ export const root = program
 export function actionHandler (fn: Function) {
   return async (source: any = {}) => {
     try {
-      const configFilePath = source.config || source?.parent?.config
+      const configFilePath = source.config || source?.parent?.config || defaultConfigFilePath
       if (configFilePath) {
         const config = await parseConfigFile(configFilePath)
         await setGlobalConfigFromConfigFile(config, source.passwordFile)

--- a/packages/hop-node/src/config/config.ts
+++ b/packages/hop-node/src/config/config.ts
@@ -17,7 +17,7 @@ require('./loadEnvFile')
 
 export const defaultDataDir = `${os.homedir()}/.hop`
 export const defaultDbDir = `${defaultDataDir}/db`
-export const defaultConfigFilePath = `${defaultDataDir}/eth.goerli.config.json`
+export const defaultConfigFilePath = `${defaultDataDir}/config.json`
 export const defaultKeystoreFilePath = `${defaultDataDir}/keystore.json`
 
 export const ipfsHost = process.env.IPFS_HOST ?? 'http://127.0.0.1:5001'

--- a/packages/hop-node/src/config/config.ts
+++ b/packages/hop-node/src/config/config.ts
@@ -2,7 +2,6 @@ import buildInfo from 'src/.build-info.json'
 import normalizeEnvVarArray from './utils/normalizeEnvVarArray'
 import normalizeEnvVarNumber from './utils/normalizeEnvVarNumber'
 import os from 'os'
-import path from 'path'
 import { Addresses, Bonders, Bridges } from '@hop-protocol/core/addresses'
 import { AvgBlockTimeSeconds, Chain, DefaultBatchBlocks, Network, OneHourMs, TotalBlocks } from 'src/constants'
 import { Bps, ChainSlug } from '@hop-protocol/core/config'
@@ -15,7 +14,11 @@ import * as mainnetConfig from './mainnet'
 import * as stagingConfig from './staging'
 import * as testConfig from './test'
 require('./loadEnvFile')
-const defaultDbPath = path.resolve(__dirname, '../../../db_data')
+
+export const defaultDataDir = `${os.homedir()}/.hop`
+export const defaultDbDir = `${defaultDataDir}/db`
+export const defaultConfigFilePath = `${defaultDataDir}/eth.goerli.config.json`
+export const defaultKeystoreFilePath = `${defaultDataDir}/keystore.json`
 
 export const ipfsHost = process.env.IPFS_HOST ?? 'http://127.0.0.1:5001'
 export const hostname = process.env.HOSTNAME ?? os.hostname()
@@ -54,9 +57,6 @@ const bonderPrivateKey = process.env.BONDER_PRIVATE_KEY
 export const oruChains: Set<string> = new Set([Chain.Optimism, Chain.Arbitrum, Chain.Nova, Chain.Base])
 export const rateLimitMaxRetries = normalizeEnvVarNumber(process.env.RATE_LIMIT_MAX_RETRIES) ?? 5
 export const rpcTimeoutSeconds = 90
-export const defaultConfigDir = `${os.homedir()}/.hop`
-export const defaultConfigFilePath = `${defaultConfigDir}/config.json`
-export const defaultKeystoreFilePath = `${defaultConfigDir}/keystore.json`
 export const minEthBonderFeeBn = parseEther('0.00001')
 export const pendingCountCommitThreshold = normalizeEnvVarNumber(process.env.PENDING_COUNT_COMMIT_THRESHOLD) ?? 921 // 90% of 1024
 export const appTld = process.env.APP_TLD ?? 'hop.exchange'
@@ -199,7 +199,7 @@ export const config: Config = {
   fees: {},
   routes: {},
   db: {
-    path: defaultDbPath
+    path: defaultDbDir
   },
   sync: {
     [Chain.Ethereum]: {

--- a/packages/ipfs-worker/.dockerignore
+++ b/packages/ipfs-worker/.dockerignore
@@ -1,3 +1,4 @@
 node_modules
 Dockerfile
 *.env
+.git

--- a/packages/stats-worker/.dockerignore
+++ b/packages/stats-worker/.dockerignore
@@ -1,3 +1,4 @@
 node_modules
 Dockerfile
 *.env
+.git


### PR DESCRIPTION
* Normalizes default data path across Linux/Mac OSes to `~/.hop`. Allows bonders to not define path's in config/CLI option if they are commonly used (config, keystore, db). 
* Runs Docker instances with `node` user with restricted capabilities. This `node` user's home dir is `/home/node`.
* Removes [`.git` from Dockerfiles](https://www.digitalocean.com/community/tutorials/how-to-build-a-node-js-application-with-docker).

In practice, a new bonder should now be able to pull the image, run `hop keystore generate`, add a pretty general config with no paths (minus their token-specific info), and run docker with `-v ~/.hop:/home/node/.hop` (that should be the only place a new bonder defines a custom path).

Local testing still uses `~/.hop` by default, unless otherwise specified.