### PR TITLE
Feat/optimized sync watcher

### DIFF
--- a/packages/hop-node/src/cli/hopNode.ts
+++ b/packages/hop-node/src/cli/hopNode.ts
@@ -38,7 +38,6 @@ root
   .option('--health-check-cache-file <filepath>', 'Health checker cache file', parseString)
   .option('--heapdump [boolean]', 'Write heapdump snapshot to a file every 5 minutes', parseBool)
   .option('--enabled-checks <enabledChecks>', 'Enabled checks. Options are: lowBonderBalances,unbondedTransfers,unbondedTransferRoots,incompleteSettlements,challengedTransferRoots,unsyncedSubgraphs,lowAvailableLiquidityBonders', parseStringArray)
-  .option('--sync-interval-multiplier <number>', 'The multiplier for polls in the SyncWatcher', parseNumber)
   .option('--arb-bot [boolean]', 'Run the Goerli arb bot', parseBool)
   .option(
     '--arb-bot-config <path>',
@@ -52,7 +51,7 @@ async function main (source: any) {
   logger.debug('starting hop node')
   logger.debug(`git revision: ${gitRev}`)
 
-  const { config, syncFromDate, s3Upload, s3Namespace, clearDb, heapdump, healthCheckDays, healthCheckCacheFile, enabledChecks, dry: dryMode, syncIntervalMultiplier, arbBot: runArbBot, arbBotConfig } = source
+  const { config, syncFromDate, s3Upload, s3Namespace, clearDb, heapdump, healthCheckDays, healthCheckCacheFile, enabledChecks, dry: dryMode, arbBot: runArbBot, arbBotConfig } = source
   if (!config) {
     throw new Error('config file is required')
   }
@@ -130,13 +129,6 @@ async function main (source: any) {
     logger.info('Bonder public address:', bonderPublicAddress)
   }
 
-  if (syncIntervalMultiplier) {
-    if (typeof syncIntervalMultiplier !== 'number' || syncIntervalMultiplier === 0) {
-      throw new Error('syncIntervalMultiplier must be a number greater than 0')
-    }
-    logger.info(`resync interval multiplier: ${syncIntervalMultiplier}`)
-  }
-
   const { starts } = await startWatchers({
     enabledWatchers: Object.keys(config.watchers).filter(
       key => config.watchers[key]
@@ -149,7 +141,6 @@ async function main (source: any) {
     settleBondedWithdrawalsThresholdPercent,
     dryMode,
     syncFromDate,
-    syncIntervalMultiplier,
     s3Upload,
     s3Namespace
   })

--- a/packages/hop-node/src/cli/hopNode.ts
+++ b/packages/hop-node/src/cli/hopNode.ts
@@ -129,6 +129,11 @@ async function main (source: any) {
     const bonderPublicAddress = computeAddress(privateKey)
     logger.info('Bonder public address:', bonderPublicAddress)
   }
+
+  if (resyncIntervalMultiplier) {
+    logger.info(`resync interval multiplier: ${resyncIntervalMultiplier}`)
+  }
+
   const { starts } = await startWatchers({
     enabledWatchers: Object.keys(config.watchers).filter(
       key => config.watchers[key]

--- a/packages/hop-node/src/cli/hopNode.ts
+++ b/packages/hop-node/src/cli/hopNode.ts
@@ -38,7 +38,7 @@ root
   .option('--health-check-cache-file <filepath>', 'Health checker cache file', parseString)
   .option('--heapdump [boolean]', 'Write heapdump snapshot to a file every 5 minutes', parseBool)
   .option('--enabled-checks <enabledChecks>', 'Enabled checks. Options are: lowBonderBalances,unbondedTransfers,unbondedTransferRoots,incompleteSettlements,challengedTransferRoots,unsyncedSubgraphs,lowAvailableLiquidityBonders', parseStringArray)
-  .option('--resync-interval-ms <number>', 'The sync interval for the SyncWatcher', parseNumber)
+  .option('--sync-interval-multiplier <number>', 'The multiplier for polls in the SyncWatcher', parseNumber)
   .option('--arb-bot [boolean]', 'Run the Goerli arb bot', parseBool)
   .option(
     '--arb-bot-config <path>',
@@ -52,7 +52,7 @@ async function main (source: any) {
   logger.debug('starting hop node')
   logger.debug(`git revision: ${gitRev}`)
 
-  const { config, syncFromDate, s3Upload, s3Namespace, clearDb, heapdump, healthCheckDays, healthCheckCacheFile, enabledChecks, dry: dryMode, resyncIntervalMultiplier, arbBot: runArbBot, arbBotConfig } = source
+  const { config, syncFromDate, s3Upload, s3Namespace, clearDb, heapdump, healthCheckDays, healthCheckCacheFile, enabledChecks, dry: dryMode, syncIntervalMultiplier, arbBot: runArbBot, arbBotConfig } = source
   if (!config) {
     throw new Error('config file is required')
   }
@@ -130,8 +130,11 @@ async function main (source: any) {
     logger.info('Bonder public address:', bonderPublicAddress)
   }
 
-  if (resyncIntervalMultiplier) {
-    logger.info(`resync interval multiplier: ${resyncIntervalMultiplier}`)
+  if (syncIntervalMultiplier) {
+    if (typeof syncIntervalMultiplier !== 'number' || syncIntervalMultiplier === 0) {
+      throw new Error('syncIntervalMultiplier must be a number greater than 0')
+    }
+    logger.info(`resync interval multiplier: ${syncIntervalMultiplier}`)
   }
 
   const { starts } = await startWatchers({
@@ -146,7 +149,7 @@ async function main (source: any) {
     settleBondedWithdrawalsThresholdPercent,
     dryMode,
     syncFromDate,
-    resyncIntervalMultiplier,
+    syncIntervalMultiplier,
     s3Upload,
     s3Namespace
   })

--- a/packages/hop-node/src/cli/hopNode.ts
+++ b/packages/hop-node/src/cli/hopNode.ts
@@ -52,7 +52,7 @@ async function main (source: any) {
   logger.debug('starting hop node')
   logger.debug(`git revision: ${gitRev}`)
 
-  const { config, syncFromDate, s3Upload, s3Namespace, clearDb, heapdump, healthCheckDays, healthCheckCacheFile, enabledChecks, dry: dryMode, resyncIntervalMs, arbBot: runArbBot, arbBotConfig } = source
+  const { config, syncFromDate, s3Upload, s3Namespace, clearDb, heapdump, healthCheckDays, healthCheckCacheFile, enabledChecks, dry: dryMode, resyncIntervalMultiplier, arbBot: runArbBot, arbBotConfig } = source
   if (!config) {
     throw new Error('config file is required')
   }
@@ -141,7 +141,7 @@ async function main (source: any) {
     settleBondedWithdrawalsThresholdPercent,
     dryMode,
     syncFromDate,
-    resyncIntervalMs,
+    resyncIntervalMultiplier,
     s3Upload,
     s3Namespace
   })

--- a/packages/hop-node/src/config/config.ts
+++ b/packages/hop-node/src/config/config.ts
@@ -70,7 +70,7 @@ export const expectedNameservers = normalizeEnvVarArray(process.env.EXPECTED_APP
 export const modifiedLiquidityRoutes = process.env.MODIFIED_LIQUIDITY_ROUTES?.split(',') ?? []
 
 export const SyncIntervalSec = process.env.SYNC_INTERVAL_SEC ? Number(process.env.SYNC_INTERVAL_SEC) : 30
-export const SyncCyclesPerFullSync = process.env.SYNC_CYCLES_PER_FULL_SYNC ? Number(process.env.DEFAULT_POLL_INTERVAL) : 60
+export const SyncCyclesPerFullSync = process.env.SYNC_CYCLES_PER_FULL_SYNC ? Number(process.env.SYNC_CYCLES_PER_FULL_SYNC) : 60
 
 export const maxPriorityFeeConfidenceLevel = normalizeEnvVarNumber(process.env.MAX_PRIORITY_FEE_CONFIDENCE_LEVEL) ?? 95
 export const blocknativeApiKey = process.env.BLOCKNATIVE_API_KEY ?? ''

--- a/packages/hop-node/src/config/config.ts
+++ b/packages/hop-node/src/config/config.ts
@@ -69,6 +69,9 @@ export const appTld = process.env.APP_TLD ?? 'hop.exchange'
 export const expectedNameservers = normalizeEnvVarArray(process.env.EXPECTED_APP_NAMESERVERS)
 export const modifiedLiquidityRoutes = process.env.MODIFIED_LIQUIDITY_ROUTES?.split(',') ?? []
 
+export const SyncIntervalSec = process.env.SYNC_INTERVAL_SEC ? Number(process.env.SYNC_INTERVAL_SEC) : 30
+export const SyncCyclesPerFullSync = process.env.SYNC_CYCLES_PER_FULL_SYNC ? Number(process.env.DEFAULT_POLL_INTERVAL) : 60
+
 export const maxPriorityFeeConfidenceLevel = normalizeEnvVarNumber(process.env.MAX_PRIORITY_FEE_CONFIDENCE_LEVEL) ?? 95
 export const blocknativeApiKey = process.env.BLOCKNATIVE_API_KEY ?? ''
 

--- a/packages/hop-node/src/config/config.ts
+++ b/packages/hop-node/src/config/config.ts
@@ -70,6 +70,7 @@ export const expectedNameservers = normalizeEnvVarArray(process.env.EXPECTED_APP
 export const modifiedLiquidityRoutes = process.env.MODIFIED_LIQUIDITY_ROUTES?.split(',') ?? []
 
 export const SyncIntervalSec = process.env.SYNC_INTERVAL_SEC ? Number(process.env.SYNC_INTERVAL_SEC) : 30
+export const SyncIntervalMultiplier = process.env.SYNC_INTERVAL_MULTIPLIER ? Number(process.env.SYNC_INTERVAL_MULTIPLIER) : 1
 export const SyncCyclesPerFullSync = process.env.SYNC_CYCLES_PER_FULL_SYNC ? Number(process.env.SYNC_CYCLES_PER_FULL_SYNC) : 60
 
 export const maxPriorityFeeConfidenceLevel = normalizeEnvVarNumber(process.env.MAX_PRIORITY_FEE_CONFIDENCE_LEVEL) ?? 95

--- a/packages/hop-node/src/config/config.ts
+++ b/packages/hop-node/src/config/config.ts
@@ -69,6 +69,8 @@ export const appTld = process.env.APP_TLD ?? 'hop.exchange'
 export const expectedNameservers = normalizeEnvVarArray(process.env.EXPECTED_APP_NAMESERVERS)
 export const modifiedLiquidityRoutes = process.env.MODIFIED_LIQUIDITY_ROUTES?.split(',') ?? []
 
+// Decreasing SyncCyclesPerFullSync will result in more full syncs (root data) more often. This is useful for the
+// available liquidity watcher to have up-to-date info
 export const SyncIntervalSec = process.env.SYNC_INTERVAL_SEC ? Number(process.env.SYNC_INTERVAL_SEC) : 30
 export const SyncIntervalMultiplier = process.env.SYNC_INTERVAL_MULTIPLIER ? Number(process.env.SYNC_INTERVAL_MULTIPLIER) : 1
 export const SyncCyclesPerFullSync = process.env.SYNC_CYCLES_PER_FULL_SYNC ? Number(process.env.SYNC_CYCLES_PER_FULL_SYNC) : 60

--- a/packages/hop-node/src/constants/constants.ts
+++ b/packages/hop-node/src/constants/constants.ts
@@ -172,7 +172,4 @@ export const SyncIterationMultiplier: Record<string, number> = {
   [Chain.PolygonZk]: 1
 }
 
-export const ShouldRelayL1ToL2Message: Record<string, boolean> = {
-  [Chain.Arbitrum]: true,
-  [Chain.Nova]: true
-}
+export const DefaultSyncIntervalSec: number = 30

--- a/packages/hop-node/src/constants/constants.ts
+++ b/packages/hop-node/src/constants/constants.ts
@@ -171,5 +171,3 @@ export const ChainSyncMultiplier: Record<string, number> = {
   [Chain.Nova]: 2,
   [Chain.PolygonZk]: 1
 }
-
-export const DefaultSyncIntervalSec: number = 30

--- a/packages/hop-node/src/constants/constants.ts
+++ b/packages/hop-node/src/constants/constants.ts
@@ -161,7 +161,7 @@ export const FinalityTagForChain: Record<string, string> = {
   [Chain.PolygonZk]: FinalityTag.Safe
 }
 
-export const SyncIterationMultiplier: Record<string, number> = {
+export const ChainSyncMultiplier: Record<string, number> = {
   [Chain.Ethereum]: 1,
   [Chain.Gnosis]: 2,
   [Chain.Polygon]: 2,

--- a/packages/hop-node/src/constants/constants.ts
+++ b/packages/hop-node/src/constants/constants.ts
@@ -160,3 +160,19 @@ export const FinalityTagForChain: Record<string, string> = {
   [Chain.Nova]: FinalityTag.Safe,
   [Chain.PolygonZk]: FinalityTag.Safe
 }
+
+export const SyncIterationMultiplier: Record<string, number> = {
+  [Chain.Ethereum]: 1,
+  [Chain.Gnosis]: 2,
+  [Chain.Polygon]: 2,
+  [Chain.Optimism]: 1,
+  [Chain.Arbitrum]: 1,
+  [Chain.Base]: 1,
+  [Chain.Nova]: 2,
+  [Chain.PolygonZk]: 1
+}
+
+export const ShouldRelayL1ToL2Message: Record<string, boolean> = {
+  [Chain.Arbitrum]: true,
+  [Chain.Nova]: true
+}

--- a/packages/hop-node/src/theGraph/getUnbondedTransfers.ts
+++ b/packages/hop-node/src/theGraph/getUnbondedTransfers.ts
@@ -6,6 +6,7 @@ import { DateTime } from 'luxon'
 import { chunk, uniqBy } from 'lodash'
 import { formatUnits } from 'ethers/lib/utils'
 import { padHex } from 'src/utils/padHex'
+import getTransferSentToL2TransferId from 'src/utils/getTransferSentToL2TransferId'
 
 export async function getUnbondedTransfers (days: number, offsetDays: number = 0) {
   const endDate = DateTime.now().toUTC()

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -236,11 +236,11 @@ class SyncWatcher extends BaseWatcher {
   async syncHandler (): Promise<any> {
     // Events that are related to user transfers can be polled every cycle while
     // all other, less time-sensitive events can be polled every N cycles
-    const slowSyncModulo = this.resyncIntervalSec * SyncIterationMultiplier[this.chainSlug]
+    const fullSyncModulo = this.resyncIntervalSec * SyncIterationMultiplier[this.chainSlug]
     let promisesPerPoll: EventPromise = []
     if (
       !this.isInitialSyncCompleted() ||
-      this.syncIndex % slowSyncModulo === 0
+      this.syncIndex % fullSyncModulo === 0
     ) {
       promisesPerPoll = this.getAllPromises()
     } else {

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -291,10 +291,9 @@ class SyncWatcher extends BaseWatcher {
     }
   }
 
-  getTransferSentToL2EventPromise (): Promise<any> {
-    if (!this.isL1) {
-      return Promise.resolve()
-    }
+  async getTransferSentToL2EventPromise (): Promise<any> {
+    if (!this.isL1) return []
+
     const l1Bridge = this.bridge as L1Bridge
     return l1Bridge.mapTransferSentToL2Events(
       event => this.handleTransferSentToL2Event(event),
@@ -302,10 +301,9 @@ class SyncWatcher extends BaseWatcher {
     )
   }
 
-  getTransferRootConfirmedEventPromise (): Promise<any> {
-    if (!this.isL1) {
-      return Promise.resolve()
-    }
+  async getTransferRootConfirmedEventPromise (): Promise<any> {
+    if (!this.isL1) return []
+
     const l1Bridge = this.bridge as L1Bridge
     return l1Bridge.mapTransferRootConfirmedEvents(
       event => this.handleTransferRootConfirmedEvent(event),
@@ -313,10 +311,9 @@ class SyncWatcher extends BaseWatcher {
     )
   }
 
-  getTransferBondChallengedEventPromise (): Promise<any> {
-    if (!this.isL1) {
-      return Promise.resolve()
-    }
+  async getTransferBondChallengedEventPromise (): Promise<any> {
+    if (!this.isL1) return []
+
     const l1Bridge = this.bridge as L1Bridge
     return l1Bridge.mapTransferBondChallengedEvents(
       event => this.handleTransferBondChallengedEvent(event),
@@ -324,10 +321,9 @@ class SyncWatcher extends BaseWatcher {
     )
   }
 
-  getTransferSentEventPromise (): Promise<any> {
-    if (this.isL1) {
-      return Promise.resolve()
-    }
+  async getTransferSentEventPromise (): Promise<any> {
+    if (this.isL1) return []
+
     const l2Bridge = this.bridge as L2Bridge
     return l2Bridge.mapTransferSentEvents(
       event => this.handleTransferSentEvent(event),
@@ -335,17 +331,16 @@ class SyncWatcher extends BaseWatcher {
     )
   }
 
-  getTransferRootSetEventPromise (): Promise<any> {
+  async getTransferRootSetEventPromise (): Promise<any> {
     return this.bridge.mapTransferRootSetEvents(
       event => this.handleTransferRootSetEvent(event),
       this.getSyncOptions(this.bridge.TransferRootSet)
     )
   }
 
-  getTransferRootBondedEventPromise (): Promise<any>{
-    if (!this.isL1) {
-      return Promise.resolve()
-    }
+  async getTransferRootBondedEventPromise (): Promise<any>{
+    if (!this.isL1) return []
+
     const l1Bridge = this.bridge as L1Bridge
     return l1Bridge.mapTransferRootBondedEvents(
       event => this.handleTransferRootBondedEvent(event),
@@ -353,10 +348,9 @@ class SyncWatcher extends BaseWatcher {
     )
   }
 
-  getTransfersCommittedEventPromise (): Promise<any> {
-    if (this.isL1) {
-      return Promise.resolve()
-    }
+  async getTransfersCommittedEventPromise (): Promise<any> {
+    if (this.isL1) return []
+
     const l2Bridge = this.bridge as L2Bridge
     return l2Bridge.mapTransfersCommittedEvents(
       event => this.handleTransfersCommittedEvent(event),
@@ -364,28 +358,28 @@ class SyncWatcher extends BaseWatcher {
     )
   }
 
-  getWithdrawalBondedEventPromise (): Promise<any> {
+  async getWithdrawalBondedEventPromise (): Promise<any> {
     return this.bridge.mapWithdrawalBondedEvents(
       event => this.handleWithdrawalBondedEvent(event),
       this.getSyncOptions(this.bridge.WithdrawalBonded)
     )
   }
 
-  getWithdrewEventPromise (): Promise<any> {
+  async getWithdrewEventPromise (): Promise<any> {
     return this.bridge.mapWithdrewEvents(
       event => this.handleWithdrewEvent(event),
       this.getSyncOptions(this.bridge.Withdrew)
     )
   }
 
-  getMultipleWithdrawalsSettledEventPromise (): Promise<any> {
+  async getMultipleWithdrawalsSettledEventPromise (): Promise<any> {
     return this.bridge.mapMultipleWithdrawalsSettledEvents(
       event => this.handleMultipleWithdrawalsSettledEvent(event),
       this.getSyncOptions(this.bridge.MultipleWithdrawalsSettled)
     )
   }
 
-  getWithdrawalBondSettledEventPromise (): Promise<any> {
+  async getWithdrawalBondSettledEventPromise (): Promise<any> {
     return this.bridge.mapWithdrawalBondSettledEvents(
       event => this.handleWithdrawalBondSettledEvent(event),
       this.getSyncOptions(this.bridge.WithdrawalBondSettled)

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -14,7 +14,7 @@ import {
   GasCostTransactionType,
   OneWeekMs,
   RelayableChains,
-  SyncIterationMultiplier
+  ChainSyncMultiplier
 } from 'src/constants'
 import { DateTime } from 'luxon'
 import { FirstRoots } from 'src/constants/firstRootsPerRoute'
@@ -78,13 +78,17 @@ class SyncWatcher extends BaseWatcher {
       this.logger.debug(`gasCostPollEnabled: ${this.gasCostPollEnabled}`)
     }
 
-    // Add resync multiplier if applicable
+    // Add resync multipliers if applicable
+    // There is a multiplier for each chain and a multiplier for each network (passed in by config)
     let configSyncMultiplier = 1
     if (typeof config.resyncIntervalMultiplier === 'number') {
       configSyncMultiplier = config.resyncIntervalMultiplier
     }
 
-    this.syncIntervalSec = DefaultSyncIntervalSec * SyncIterationMultiplier[this.chainSlug] * configSyncMultiplier
+    if (ChainSyncMultiplier[this.chainSlug] === 0 || configSyncMultiplier === 0) {
+      throw new Error(`invalid sync multiplier for chain ${this.chainSlug}: ${ChainSyncMultiplier[this.chainSlug]}, ${configSyncMultiplier}`)
+    }
+    this.syncIntervalSec = DefaultSyncIntervalSec * ChainSyncMultiplier[this.chainSlug] * configSyncMultiplier
     this.syncIntervalMs = this.syncIntervalSec * 1000
     this.logger.debug(`syncIntervalSec set to ${this.syncIntervalSec} (${this.syncIntervalMs} ms)`)
 

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -236,7 +236,10 @@ class SyncWatcher extends BaseWatcher {
   async syncHandler (): Promise<any> {
     // Events that are related to user transfers can be polled every cycle while
     // all other, less time-sensitive events can be polled every N cycles
-    const fullSyncModulo = this.resyncIntervalSec * SyncIterationMultiplier[this.chainSlug]
+
+    // The number of cycles between syncs should be a multiplier of the time it takes to sync
+    const numberOfCyclesBetweenSyncs = this.resyncIntervalSec * 2
+    const fullSyncModulo = numberOfCyclesBetweenSyncs * SyncIterationMultiplier[this.chainSlug]
     let promisesPerPoll: EventPromise = []
     if (
       !this.isInitialSyncCompleted() ||

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -244,7 +244,7 @@ class SyncWatcher extends BaseWatcher {
     ) {
       promisesPerPoll = this.getAllPromises()
     } else {
-      promisesPerPoll = this.getTransferSendPromises()
+      promisesPerPoll = this.getTransferSentPromises()
     }
 
     // these must come after db is done syncing, and syncAvailableCredit must be last
@@ -416,7 +416,7 @@ class SyncWatcher extends BaseWatcher {
     ]
   }
 
-  getTransferSendPromises (): EventPromise {
+  getTransferSentPromises (): EventPromise {
     if (ShouldRelayL1ToL2Message[this.chainSlug]) {
       return [
         this.getTransferSentEventPromise(),

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -433,15 +433,15 @@ class SyncWatcher extends BaseWatcher {
   }
 
   getTransferSentPromises (): EventPromise {
-    if (this.isL1 && this.isRelayableChainEnabled) {
-      return [
-        this.getTransferSentEventPromise(),
-        this.getTransferSentToL2EventPromise(),
-      ]
+    // If a relayable chain is enabled, listen for TransferSentToL2 events on L1
+    if (this.isL1) {
+      if (this.isRelayableChainEnabled) {
+        return [this.getTransferSentToL2EventPromise()]
+      }
+    } else {
+      return [this.getTransferSentEventPromise()]
     }
-    return [
-      this.getTransferSentEventPromise(),
-    ]
+    return []
   }
 
   async handleTransferSentToL2Event (event: TransferSentToL2Event) {

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -259,10 +259,7 @@ class SyncWatcher extends BaseWatcher {
     // Events that are related to user transfers can be polled every cycle while all other, less
     // time-sensitive events can be polled every N cycles.
     let promisesPerPoll: EventPromise = []
-    if (
-      !this.isInitialSyncCompleted() ||
-      this.shouldSyncAllEvents()
-    ) {
+    if (this.shouldSyncAllEvents()) {
       promisesPerPoll = this.getAllPromises()
     } else {
       promisesPerPoll = this.getTransferSentPromises()
@@ -274,7 +271,11 @@ class SyncWatcher extends BaseWatcher {
   }
 
   shouldSyncAllEvents(): boolean {
-    return this.syncIndex % SyncCyclesPerFullSync === 0
+    return !this.isInitialSyncCompleted() || this.isAtNewFullSyncCycleIndex()
+  }
+
+  isAtNewFullSyncCycleIndex(): boolean {
+      return this.syncIndex % SyncCyclesPerFullSync === 0
   }
 
   getSyncOptions (keyName: string) {
@@ -296,9 +297,7 @@ class SyncWatcher extends BaseWatcher {
     }
     const l1Bridge = this.bridge as L1Bridge
     return l1Bridge.mapTransferSentToL2Events(
-      async (event: TransferSentToL2Event) => {
-        return await this.handleTransferSentToL2Event(event)
-      },
+      event => this.handleTransferSentToL2Event(event),
       this.getSyncOptions(l1Bridge.TransferSentToL2)
     )
   }
@@ -309,9 +308,7 @@ class SyncWatcher extends BaseWatcher {
     }
     const l1Bridge = this.bridge as L1Bridge
     return l1Bridge.mapTransferRootConfirmedEvents(
-      async (event: TransferRootConfirmedEvent) => {
-        return await this.handleTransferRootConfirmedEvent(event)
-      },
+      event => this.handleTransferRootConfirmedEvent(event),
       this.getSyncOptions(l1Bridge.TransferRootConfirmed)
     )
   }
@@ -322,9 +319,7 @@ class SyncWatcher extends BaseWatcher {
     }
     const l1Bridge = this.bridge as L1Bridge
     return l1Bridge.mapTransferBondChallengedEvents(
-      async (event: TransferBondChallengedEvent) => {
-        return await this.handleTransferBondChallengedEvent(event)
-      },
+      event => this.handleTransferBondChallengedEvent(event),
       this.getSyncOptions(l1Bridge.TransferBondChallenged)
     )
   }
@@ -335,18 +330,14 @@ class SyncWatcher extends BaseWatcher {
     }
     const l2Bridge = this.bridge as L2Bridge
     return l2Bridge.mapTransferSentEvents(
-      async (event: TransferSentEvent) => {
-        return await this.handleTransferSentEvent(event)
-      },
+      event => this.handleTransferSentEvent(event),
       this.getSyncOptions(l2Bridge.TransferSent)
     )
   }
 
   getTransferRootSetEventPromise (): Promise<any> {
     return this.bridge.mapTransferRootSetEvents(
-      async (event: TransferRootSetEvent) => {
-        return await this.handleTransferRootSetEvent(event)
-      },
+      event => this.handleTransferRootSetEvent(event),
       this.getSyncOptions(this.bridge.TransferRootSet)
     )
   }
@@ -357,9 +348,7 @@ class SyncWatcher extends BaseWatcher {
     }
     const l1Bridge = this.bridge as L1Bridge
     return l1Bridge.mapTransferRootBondedEvents(
-      async (event: TransferRootBondedEvent) => {
-        return await this.handleTransferRootBondedEvent(event)
-      },
+      event => this.handleTransferRootBondedEvent(event),
       this.getSyncOptions(l1Bridge.TransferRootBonded)
     )
   }
@@ -370,45 +359,35 @@ class SyncWatcher extends BaseWatcher {
     }
     const l2Bridge = this.bridge as L2Bridge
     return l2Bridge.mapTransfersCommittedEvents(
-      async (event: TransfersCommittedEvent) => {
-        return this.handleTransfersCommittedEvent(event)
-      },
+      event => this.handleTransfersCommittedEvent(event),
       this.getSyncOptions(l2Bridge.TransfersCommitted)
     )
   }
 
   getWithdrawalBondedEventPromise (): Promise<any> {
     return this.bridge.mapWithdrawalBondedEvents(
-      async (event: WithdrawalBondedEvent) => {
-        return await this.handleWithdrawalBondedEvent(event)
-      },
+      event => this.handleWithdrawalBondedEvent(event),
       this.getSyncOptions(this.bridge.WithdrawalBonded)
     )
   }
 
   getWithdrewEventPromise (): Promise<any> {
     return this.bridge.mapWithdrewEvents(
-      async (event: WithdrewEvent) => {
-        return await this.handleWithdrewEvent(event)
-      },
+      event => this.handleWithdrewEvent(event),
       this.getSyncOptions(this.bridge.Withdrew)
     )
   }
 
   getMultipleWithdrawalsSettledEventPromise (): Promise<any> {
     return this.bridge.mapMultipleWithdrawalsSettledEvents(
-      async (event: MultipleWithdrawalsSettledEvent) => {
-        return await this.handleMultipleWithdrawalsSettledEvent(event)
-      },
+      event => this.handleMultipleWithdrawalsSettledEvent(event),
       this.getSyncOptions(this.bridge.MultipleWithdrawalsSettled)
     )
   }
 
   getWithdrawalBondSettledEventPromise (): Promise<any> {
     return this.bridge.mapWithdrawalBondSettledEvents(
-      async (event: WithdrawalBondSettledEvent) => {
-        return await this.handleWithdrawalBondSettledEvent(event)
-      },
+      event => this.handleWithdrawalBondSettledEvent(event),
       this.getSyncOptions(this.bridge.WithdrawalBondSettled)
     )
   }

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -349,7 +349,7 @@ class SyncWatcher extends BaseWatcher {
     const l2Bridge = this.bridge as L2Bridge
     return l2Bridge.mapTransfersCommittedEvents(
       async (event: TransfersCommittedEvent) => {
-        this.handleTransfersCommittedEvent(event)
+        return this.handleTransfersCommittedEvent(event)
       },
       this.getSyncOptions(l2Bridge.TransfersCommitted)
     )

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -41,6 +41,7 @@ import { TransferRoot } from 'src/db/TransferRootsDb'
 import { getSortedTransferIds } from 'src/utils/getSortedTransferIds'
 import {
   SyncCyclesPerFullSync,
+  SyncIntervalMultiplier,
   SyncIntervalSec,
   getEnabledNetworks,
   config as globalConfig,
@@ -54,7 +55,6 @@ type Config = {
   tokenSymbol: string
   bridgeContract: L1BridgeContract | L2BridgeContract
   syncFromDate?: string
-  syncIntervalMultiplier?: number
   gasCostPollEnabled?: boolean
 }
 
@@ -87,7 +87,7 @@ class SyncWatcher extends BaseWatcher {
 
     // There is a multiplier for each chain and a multiplier for each network (passed in by config)
     const chainSyncMultiplier = ChainSyncMultiplier?.[this.chainSlug] ?? 1
-    const networkSyncMultiplier = config?.syncIntervalMultiplier ?? 1
+    const networkSyncMultiplier = SyncIntervalMultiplier
     this.syncIntervalSec = SyncIntervalSec * chainSyncMultiplier * networkSyncMultiplier
     this.syncIntervalMs = this.syncIntervalSec * 1000
     this.logger.debug(`syncIntervalSec set to ${this.syncIntervalSec} (${this.syncIntervalMs} ms). chainSyncMultiplier: ${chainSyncMultiplier}, networkSyncMultiplier: ${networkSyncMultiplier}`)

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -256,14 +256,12 @@ class SyncWatcher extends BaseWatcher {
   }
 
   async syncHandler (): Promise<any> {
-    // Events that are related to user transfers can be polled every cycle while
-    // all other, less time-sensitive events can be polled every N cycles.
-    // If SyncCyclesPerFullSync is 60, then the default values will be 30 seconds for the transferSent
-    // events and 30 minutes for the rest of the events.
+    // Events that are related to user transfers can be polled every cycle while all other, less
+    // time-sensitive events can be polled every N cycles.
     let promisesPerPoll: EventPromise = []
     if (
       !this.isInitialSyncCompleted() ||
-      this.syncIndex % SyncCyclesPerFullSync === 0
+      this.shouldSyncAllEvents()
     ) {
       promisesPerPoll = this.getAllPromises()
     } else {
@@ -273,6 +271,10 @@ class SyncWatcher extends BaseWatcher {
     // these must come after db is done syncing, and syncAvailableCredit must be last
     await Promise.all(promisesPerPoll)
       .then(async () => await this.availableLiquidityWatcher.syncBonderCredit())
+  }
+
+  shouldSyncAllEvents(): boolean {
+    return this.syncIndex % SyncCyclesPerFullSync === 0
   }
 
   getSyncOptions (keyName: string) {

--- a/packages/hop-node/src/watchers/SyncWatcher.ts
+++ b/packages/hop-node/src/watchers/SyncWatcher.ts
@@ -62,7 +62,6 @@ type EventPromise = Array<Promise<any>>
 
 class SyncWatcher extends BaseWatcher {
   initialSyncCompleted: boolean = false
-  syncIntervalSec: number
   syncIntervalMs: number
   gasCostPollMs: number = 60 * 1000
   gasCostPollEnabled: boolean = false
@@ -88,9 +87,9 @@ class SyncWatcher extends BaseWatcher {
     // There is a multiplier for each chain and a multiplier for each network (passed in by config)
     const chainSyncMultiplier = ChainSyncMultiplier?.[this.chainSlug] ?? 1
     const networkSyncMultiplier = SyncIntervalMultiplier
-    this.syncIntervalSec = SyncIntervalSec * chainSyncMultiplier * networkSyncMultiplier
-    this.syncIntervalMs = this.syncIntervalSec * 1000
-    this.logger.debug(`syncIntervalSec set to ${this.syncIntervalSec} (${this.syncIntervalMs} ms). chainSyncMultiplier: ${chainSyncMultiplier}, networkSyncMultiplier: ${networkSyncMultiplier}`)
+    const syncIntervalSec = SyncIntervalSec * chainSyncMultiplier * networkSyncMultiplier
+    this.syncIntervalMs = syncIntervalSec * 1000
+    this.logger.debug(`syncIntervalMs set to ${this.syncIntervalMs}. chainSyncMultiplier: ${chainSyncMultiplier}, networkSyncMultiplier: ${networkSyncMultiplier}`)
 
     if (this.syncIntervalMs > TenMinutesMs) {
       this.logger.error('syncIntervalMs must be less than 10 minutes. Please use a lower multiplier')
@@ -101,6 +100,7 @@ class SyncWatcher extends BaseWatcher {
     for (const enabledNetwork of enabledNetworks) {
       if (RelayableChains.includes(enabledNetwork)) {
         this.isRelayableChainEnabled = true
+        break
       }
     }
 

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -28,6 +28,14 @@ export type CanonicalTokenConvertOptions = {
   shouldSkipNearestCheck?: boolean
 }
 
+type BlockValues = {
+  end: number
+  start: number
+  batchBlocks?: number
+  earliestBlockInBatch: number
+  latestBlockInBatch: number
+}
+
 export type EventCb<E extends Event, R> = (event: E, i?: number) => R
 type BridgeContract = L1BridgeContract | L1ERC20BridgeContract | L2BridgeContract
 
@@ -574,16 +582,47 @@ export default class Bridge extends ContractBase {
       state = await this.db.syncState.getByKey(syncCacheKey)
     }
 
-    const blockValues = await this.getBlockValues(options, state)
+    const blockValues: BlockValues = await this.getBlockValues(options, state)
     let {
       start,
       end,
-      batchBlocks,
       earliestBlockInBatch,
       latestBlockInBatch
     } = blockValues
 
     this.logger.debug(`eventsBatch syncCacheKey: ${syncCacheKey} getBlockValues: ${JSON.stringify(blockValues)}`)
+
+    // If the syncer is already at the head, do not fall into the while loop since that uses
+    // an unnecessary getLogs call
+    const isAtHead = (
+      start === end &&
+      start === earliestBlockInBatch &&
+      end === latestBlockInBatch
+    )
+
+    let traversalStart = start
+    if (!isAtHead) {
+      traversalStart = await this.traverseBlockRange(cb, blockValues)
+    }
+
+    // Only store latest block if a sync is successful. Sync is complete when the start block is reached since
+    // it traverses backwards from head.
+    // NOTE: The syncCacheKey here enforces that the syncState is only updated during a sync and not when this
+    // is called for other purposes, such as looking onchain for transferIds in a root.
+    if (syncCacheKey && traversalStart === earliestBlockInBatch) {
+      this.logger.debug(`eventsBatch syncCacheKey: ${syncCacheKey} syncState latestBlockInBatch: ${latestBlockInBatch}`)
+      await this.db.syncState.update(syncCacheKey, {
+        latestBlockSynced: latestBlockInBatch,
+        timestamp: Date.now()
+      })
+    }
+  }
+
+  private readonly traverseBlockRange = async (
+    cb: (start?: number, end?: number, i?: number) => Promise<boolean | undefined> | Promise<void>,
+    blockValues: BlockValues
+  ): Promise<number> => {
+    let { start, end, batchBlocks, earliestBlockInBatch } = blockValues
 
     let i = 0
     while (start >= earliestBlockInBatch) {
@@ -605,20 +644,10 @@ export default class Bridge extends ContractBase {
       i++
     }
 
-    // Only store latest block if a sync is successful. Sync is complete when the start block is reached since
-    // it traverses backwards from head.
-    // NOTE: The syncCacheKey here enforces that the syncState is only updated during a sync and not when this
-    // is called for other purposes, such as looking onchain for transferIds in a root.
-    if (syncCacheKey && start === earliestBlockInBatch) {
-      this.logger.debug(`eventsBatch syncCacheKey: ${syncCacheKey} syncState latestBlockInBatch: ${latestBlockInBatch}`)
-      await this.db.syncState.update(syncCacheKey, {
-        latestBlockSynced: latestBlockInBatch,
-        timestamp: Date.now()
-      })
-    }
+    return start
   }
 
-  private readonly getBlockValues = async (options: Partial<EventsBatchOptions>, state?: State) => {
+  private readonly getBlockValues = async (options: Partial<EventsBatchOptions>, state?: State): Promise<BlockValues> => {
     const { startBlockNumber, endBlockNumber } = options
 
     let end: number

--- a/packages/hop-node/src/watchers/classes/Bridge.ts
+++ b/packages/hop-node/src/watchers/classes/Bridge.ts
@@ -597,7 +597,7 @@ export default class Bridge extends ContractBase {
     const isAtHead = (
       start === end &&
       start === earliestBlockInBatch &&
-      end === latestBlockInBatch
+      start === latestBlockInBatch
     )
 
     let traversalStart = start

--- a/packages/hop-node/src/watchers/watchers.ts
+++ b/packages/hop-node/src/watchers/watchers.ts
@@ -51,7 +51,6 @@ type GetWatchersConfig = {
   settleBondedWithdrawalsThresholdPercent?: SettleBondedWithdrawalsThresholdPercent
   dryMode?: boolean
   syncFromDate?: string
-  syncIntervalMultiplier?: number
   s3Upload?: boolean
   s3Namespace?: string
 }
@@ -90,7 +89,6 @@ export async function getWatchers (config: GetWatchersConfig) {
     settleBondedWithdrawalsThresholdPercent = {},
     dryMode = false,
     syncFromDate,
-    syncIntervalMultiplier,
     s3Upload,
     s3Namespace
   } = config
@@ -192,7 +190,6 @@ export async function getWatchers (config: GetWatchersConfig) {
       tokenSymbol,
       bridgeContract,
       syncFromDate,
-      syncIntervalMultiplier,
       gasCostPollEnabled
     })
   })

--- a/packages/hop-node/src/watchers/watchers.ts
+++ b/packages/hop-node/src/watchers/watchers.ts
@@ -51,7 +51,7 @@ type GetWatchersConfig = {
   settleBondedWithdrawalsThresholdPercent?: SettleBondedWithdrawalsThresholdPercent
   dryMode?: boolean
   syncFromDate?: string
-  resyncIntervalMultiplier?: number
+  syncIntervalMultiplier?: number
   s3Upload?: boolean
   s3Namespace?: string
 }
@@ -90,7 +90,7 @@ export async function getWatchers (config: GetWatchersConfig) {
     settleBondedWithdrawalsThresholdPercent = {},
     dryMode = false,
     syncFromDate,
-    resyncIntervalMultiplier,
+    syncIntervalMultiplier,
     s3Upload,
     s3Namespace
   } = config
@@ -192,7 +192,7 @@ export async function getWatchers (config: GetWatchersConfig) {
       tokenSymbol,
       bridgeContract,
       syncFromDate,
-      resyncIntervalMultiplier,
+      syncIntervalMultiplier,
       gasCostPollEnabled
     })
   })

--- a/packages/hop-node/src/watchers/watchers.ts
+++ b/packages/hop-node/src/watchers/watchers.ts
@@ -51,7 +51,7 @@ type GetWatchersConfig = {
   settleBondedWithdrawalsThresholdPercent?: SettleBondedWithdrawalsThresholdPercent
   dryMode?: boolean
   syncFromDate?: string
-  resyncIntervalMs?: number
+  resyncIntervalMultiplier?: number
   s3Upload?: boolean
   s3Namespace?: string
 }
@@ -90,7 +90,7 @@ export async function getWatchers (config: GetWatchersConfig) {
     settleBondedWithdrawalsThresholdPercent = {},
     dryMode = false,
     syncFromDate,
-    resyncIntervalMs,
+    resyncIntervalMultiplier,
     s3Upload,
     s3Namespace
   } = config
@@ -192,7 +192,7 @@ export async function getWatchers (config: GetWatchersConfig) {
       tokenSymbol,
       bridgeContract,
       syncFromDate,
-      resyncIntervalMs,
+      resyncIntervalMultiplier,
       gasCostPollEnabled
     })
   })


### PR DESCRIPTION
Optimizes the sync watcher with a few changes and new features.

* Default sync cycle time updated to 30 sec (from 60 sec)
* `TransferSent` (and `TransferSentToL2` on relayable chains) events are retrieved every cycle while all others are retrieved on a different cadence (currently 60x the default cycle time, or 30 mins).
* Introduce a multiplier `SyncIterationMultiplier` for less-used chains. This multiplier updates the default cycle time (30 sec) to something like 60 sec.
* Minor optimization: the bonder was making a `getLogs` call every cycle, even if the latest known block was already at the head. Now, if the chain head is already known by the bonder, they will not make a `getLogs` call anymore.