### PR TITLE
Feat/template method pattern

### DIFF
--- a/packages/hop-node/src/chains/Chains/arbitrum/ArbitrumMessageService.ts
+++ b/packages/hop-node/src/chains/Chains/arbitrum/ArbitrumMessageService.ts
@@ -20,16 +20,9 @@ type MessageStatus = L1ToL2MessageStatus | L2ToL1MessageStatus
 export class ArbitrumMessageService extends AbstractMessageService<Message, MessageStatus> implements IMessageService {
   protected async sendRelayTx (message: Message, messageDirection: MessageDirection): Promise<providers.TransactionResponse> {
     if (messageDirection === MessageDirection.L1_TO_L2) {
-      return this.#sendL1ToL2RelayTx(message)
+      return (message as IL1ToL2MessageWriter).redeem()
     }
-    return this.#sendL2ToL1RelayTx(message)
-  }
 
-  async #sendL1ToL2RelayTx (message: Message): Promise<providers.TransactionResponse> {
-    return (message as IL1ToL2MessageWriter).redeem()
-  }
-
-  async #sendL2ToL1RelayTx (message: Message): Promise<providers.TransactionResponse> {
     const overrides: any = {
       gasLimit: CanonicalMessengerRootConfirmationGasLimit
     }

--- a/packages/hop-node/src/chains/Chains/arbitrum/ArbitrumMessageService.ts
+++ b/packages/hop-node/src/chains/Chains/arbitrum/ArbitrumMessageService.ts
@@ -16,59 +16,41 @@ import { providers } from 'ethers'
 
 type Message = IL1ToL2MessageWriter | IL2ToL1MessageWriter
 type MessageStatus = L1ToL2MessageStatus | L2ToL1MessageStatus
-type MessageOpts = {
-  messageDirection: MessageDirection
-  messageIndex: number
-}
 
-export class ArbitrumMessageService extends AbstractMessageService<Message, MessageStatus, MessageOpts> implements IMessageService {
-  async relayL1ToL2Message (l1TxHash: string, messageIndex?: number): Promise<providers.TransactionResponse> {
-    const messageOpts: MessageOpts = {
-      messageDirection: MessageDirection.L1_TO_L2,
-      messageIndex: messageIndex ?? 0
-    }
-    return this.validateMessageAndSendTransaction(l1TxHash, messageOpts)
-  }
-
-  async relayL2ToL1Message (l2TxHash: string, messageIndex?: number): Promise<providers.TransactionResponse> {
-    const messageOpts: MessageOpts = {
-      messageDirection: MessageDirection.L2_TO_L1,
-      messageIndex: messageIndex ?? 0
-    }
-    return this.validateMessageAndSendTransaction(l2TxHash, messageOpts)
-  }
-
-  protected async sendRelayTransaction (message: Message, messageOpts: MessageOpts): Promise<providers.TransactionResponse> {
-    if (messageOpts.messageDirection === MessageDirection.L1_TO_L2) {
-      return (message as IL1ToL2MessageWriter).redeem()
-    } else {
-      const overrides: any = {
-        gasLimit: CanonicalMessengerRootConfirmationGasLimit
-      }
-      return (message as IL2ToL1MessageWriter).execute(this.l2Wallet.provider!, overrides)
-    }
-  }
-
-  protected async getMessage (txHash: string, messageOpts: MessageOpts): Promise<Message> {
-    const { messageDirection, messageIndex } = messageOpts
-
-    let messages: Message[]
+export class ArbitrumMessageService extends AbstractMessageService<Message, MessageStatus> implements IMessageService {
+  protected async sendRelayTx (message: Message, messageDirection: MessageDirection): Promise<providers.TransactionResponse> {
     if (messageDirection === MessageDirection.L1_TO_L2) {
-      const txReceipt: providers.TransactionReceipt = await this.l1Wallet.provider!.getTransactionReceipt(txHash)
-      if (!txReceipt) {
-        throw new Error(`txReceipt not found for tx hash ${txHash}`)
-      }
-      const arbitrumTxReceipt: L1TransactionReceipt = new L1TransactionReceipt(txReceipt)
-      messages = await arbitrumTxReceipt.getL1ToL2Messages(this.l2Wallet) as Message[]
-    } else {
-      const txReceipt: providers.TransactionReceipt = await this.l2Wallet.provider!.getTransactionReceipt(txHash)
-      if (!txReceipt) {
-        throw new Error(`txReceipt not found for tx hash ${txHash}`)
-      }
-      const arbitrumTxReceipt: L2TransactionReceipt = new L2TransactionReceipt(txReceipt)
-      messages = await arbitrumTxReceipt.getL2ToL1Messages(this.l1Wallet, this.l2Wallet.provider!) as Message[]
+      return this.#sendL1ToL2RelayTx(message)
     }
+    return this.#sendL2ToL1RelayTx(message)
+  }
 
+  async #sendL1ToL2RelayTx (message: Message): Promise<providers.TransactionResponse> {
+    return (message as IL1ToL2MessageWriter).redeem()
+  }
+
+  async #sendL2ToL1RelayTx (message: Message): Promise<providers.TransactionResponse> {
+    const overrides: any = {
+      gasLimit: CanonicalMessengerRootConfirmationGasLimit
+    }
+    return (message as IL2ToL1MessageWriter).execute(this.l2Wallet.provider!, overrides)
+  }
+
+  protected async getMessage (txHash: string, messageDirection: MessageDirection, messageIndex?: number): Promise<Message> {
+    messageIndex ??= 0
+    if (messageDirection === MessageDirection.L1_TO_L2) {
+      return this.#getL1ToL2Message(txHash, messageIndex)
+    }
+    return this.#getL2ToL1Message(txHash, messageIndex)
+  }
+
+  async #getL1ToL2Message (txHash: string, messageIndex: number): Promise<Message> {
+    const txReceipt: providers.TransactionReceipt = await this.l1Wallet.provider!.getTransactionReceipt(txHash)
+    if (!txReceipt) {
+      throw new Error(`txReceipt not found for tx hash ${txHash}`)
+    }
+    const arbitrumTxReceipt: L1TransactionReceipt = new L1TransactionReceipt(txReceipt)
+    const messages: Message[] = await arbitrumTxReceipt.getL1ToL2Messages(this.l2Wallet) as Message[]
     if (!messages) {
       throw new Error('could not find messages for tx hash')
     }
@@ -76,39 +58,47 @@ export class ArbitrumMessageService extends AbstractMessageService<Message, Mess
     return messages[messageIndex]
   }
 
-  protected async getMessageStatus (message: Message, messageOpts: MessageOpts): Promise<MessageStatus> {
-    // Note: the rateLimitRetry provider should not retry if calls fail here so it doesn't exponentially backoff as it retries an on-chain call
-    const { messageDirection } = messageOpts
+  async #getL2ToL1Message (txHash: string, messageIndex: number): Promise<Message> {
+    const txReceipt: providers.TransactionReceipt = await this.l2Wallet.provider!.getTransactionReceipt(txHash)
+    if (!txReceipt) {
+      throw new Error(`txReceipt not found for tx hash ${txHash}`)
+    }
+    const arbitrumTxReceipt: L2TransactionReceipt = new L2TransactionReceipt(txReceipt)
+    const messages: Message[] = await arbitrumTxReceipt.getL2ToL1Messages(this.l1Wallet, this.l2Wallet.provider!) as Message[]
+    if (!messages) {
+      throw new Error('could not find messages for tx hash')
+    }
 
+    return messages[messageIndex]
+  }
+
+  protected async getMessageStatus (message: Message, messageDirection: MessageDirection): Promise<MessageStatus> {
+    // Note: the rateLimitRetry provider should not retry if calls fail here so it doesn't exponentially backoff as it retries an on-chain call
     const statusInput: any = {}
     if (messageDirection === MessageDirection.L2_TO_L1) {
       statusInput.l2Provider = this.l2Wallet.provider!
     }
-    const res = await message.status(statusInput)
-    return res
+    return message.status(statusInput)
   }
 
-  protected isMessageInFlight (messageStatus: MessageStatus, messageOpts: MessageOpts): boolean {
-    if (messageOpts.messageDirection === MessageDirection.L1_TO_L2) {
+  protected isMessageInFlight (messageStatus: MessageStatus, messageDirection: MessageDirection): boolean {
+    if (messageDirection === MessageDirection.L1_TO_L2) {
       return messageStatus === L1ToL2MessageStatus.NOT_YET_CREATED
-    } else {
-      return messageStatus === L2ToL1MessageStatus.UNCONFIRMED
     }
+    return messageStatus === L2ToL1MessageStatus.UNCONFIRMED
   }
 
-  protected isMessageRelayable (messageStatus: MessageStatus, messageOpts: MessageOpts): boolean {
-    if (messageOpts.messageDirection === MessageDirection.L1_TO_L2) {
+  protected isMessageRelayable (messageStatus: MessageStatus, messageDirection: MessageDirection): boolean {
+    if (messageDirection === MessageDirection.L1_TO_L2) {
       return messageStatus === L1ToL2MessageStatus.FUNDS_DEPOSITED_ON_L2
-    } else {
-      return messageStatus === L2ToL1MessageStatus.CONFIRMED
     }
+    return messageStatus === L2ToL1MessageStatus.CONFIRMED
   }
 
-  protected isMessageRelayed (messageStatus: MessageStatus, messageOpts: MessageOpts): boolean {
-    if (messageOpts.messageDirection === MessageDirection.L1_TO_L2) {
+  protected isMessageRelayed (messageStatus: MessageStatus, messageDirection: MessageDirection): boolean {
+    if (messageDirection === MessageDirection.L1_TO_L2) {
       return messageStatus === L1ToL2MessageStatus.REDEEMED
-    } else {
-      return messageStatus === L2ToL1MessageStatus.EXECUTED
     }
+    return messageStatus === L2ToL1MessageStatus.EXECUTED
   }
 }

--- a/packages/hop-node/src/chains/Chains/gnosis/GnosisMessageService.ts
+++ b/packages/hop-node/src/chains/Chains/gnosis/GnosisMessageService.ts
@@ -36,8 +36,8 @@ export class GnosisMessageService extends AbstractMessageService<Message, Messag
     this.#l2Amb = new Contract(l2AmbAddress, l2xDaiAmbAbi, this.l2Wallet) as L2_xDaiAMB
   }
 
-  async relayL2ToL1Message (l2TxHash: string): Promise<providers.TransactionResponse> {
-    return this.validateMessageAndSendTransaction(l2TxHash)
+  async relayL1ToL2Message (l1TxHash: string): Promise<providers.TransactionResponse> {
+    throw new Error('L1 to L2 message relay not supported. Messages are relayed with a system tx.')
   }
 
   async #getValidSigEvent (l2TxHash: string) {
@@ -95,7 +95,7 @@ export class GnosisMessageService extends AbstractMessageService<Message, Messag
     return `0x${msgLength}${v}${r}${s}`
   }
 
-  protected async sendRelayTransaction (message: MessageStatus): Promise<providers.TransactionResponse> {
+  protected async sendRelayTx (message: MessageStatus): Promise<providers.TransactionResponse> {
     const messageHash: string = this.#getMessageHash(message)
     const requiredSigs = (await this.#l2Amb.requiredSignatures()).toNumber()
     const sigs: any[] = []

--- a/packages/hop-node/src/chains/Chains/linea/LineaMessageService.ts
+++ b/packages/hop-node/src/chains/Chains/linea/LineaMessageService.ts
@@ -21,12 +21,7 @@ interface LineaBridges {
   destBridge: LineaMessageServiceContract
 }
 
-type MessageOpts = {
-  messageDirection: MessageDirection
-  messageIndex: number
-}
-
-export class LineaMessageService extends AbstractMessageService<LineaMessage, OnChainMessageStatus, MessageOpts> implements IMessageService {
+export class LineaMessageService extends AbstractMessageService<LineaMessage, OnChainMessageStatus> implements IMessageService {
   readonly #l1Contract: LineaMessageServiceContract
   readonly #l2Contract: LineaMessageServiceContract
 
@@ -52,31 +47,15 @@ export class LineaMessageService extends AbstractMessageService<LineaMessage, On
     this.#l2Contract = lineaSdk.getL2Contract()
   }
 
-  async relayL1ToL2Message (l1TxHash: string, messageIndex?: number): Promise<providers.TransactionResponse> {
-    const messageOpts: MessageOpts = {
-      messageDirection: MessageDirection.L1_TO_L2,
-      messageIndex: messageIndex ?? 0
-    }
-    return this.validateMessageAndSendTransaction(l1TxHash, messageOpts)
-  }
-
-  async relayL2ToL1Message (l2TxHash: string, messageIndex?: number): Promise<providers.TransactionResponse> {
-    const messageOpts: MessageOpts = {
-      messageDirection: MessageDirection.L2_TO_L1,
-      messageIndex: messageIndex ?? 0
-    }
-    return this.validateMessageAndSendTransaction(l2TxHash, messageOpts)
-  }
-
-  protected async sendRelayTransaction (message: LineaMessage, opts: MessageOpts): Promise<providers.TransactionResponse> {
-    const { destBridge } = this.#getSourceAndDestBridge(opts.messageDirection)
+  protected async sendRelayTx (message: LineaMessage, messageDirection: MessageDirection): Promise<providers.TransactionResponse> {
+    const { destBridge } = this.#getSourceAndDestBridge(messageDirection)
     // Gas estimation does not work sometimes, so manual limit is needed
     // https://lineascan.build/tx/0x8e3c6d7bd3b7d39154c9463535a576db1a1e4d1e99d3a6526feb5bde26a926c0#internal
     const gasLimit = 500000
     const txOverrides = { gasLimit }
     // When the fee recipient is the zero address, the fee is sent to the msg.sender
     const feeRecipient = constants.AddressZero
-    const wallet = opts.messageDirection === MessageDirection.L1_TO_L2 ? this.l2Wallet : this.l1Wallet
+    const wallet = messageDirection === MessageDirection.L1_TO_L2 ? this.l2Wallet : this.l1Wallet
     return await destBridge.contract.connect(wallet).claimMessage(
       message.messageSender,
       message.destination,
@@ -89,9 +68,8 @@ export class LineaMessageService extends AbstractMessageService<LineaMessage, On
     )
   }
 
-  protected async getMessage (txHash: string, opts: MessageOpts): Promise<LineaMessage> {
-    const { messageIndex } = opts
-    const { sourceBridge } = this.#getSourceAndDestBridge(opts.messageDirection)
+  protected async getMessage (txHash: string, messageDirection: MessageDirection, messageIndex: number): Promise<LineaMessage> {
+    const { sourceBridge } = this.#getSourceAndDestBridge(messageDirection)
     const messages: LineaMessage[] | null = await sourceBridge.getMessagesByTransactionHash(txHash)
     if (!messages?.length) {
       throw new Error('could not find messages for tx hash')
@@ -99,8 +77,8 @@ export class LineaMessageService extends AbstractMessageService<LineaMessage, On
     return messages[messageIndex]
   }
 
-  protected async getMessageStatus (message: LineaMessage, opts: MessageOpts): Promise<OnChainMessageStatus> {
-    const { destBridge } = this.#getSourceAndDestBridge(opts.messageDirection)
+  protected async getMessageStatus (message: LineaMessage, messageDirection: MessageDirection): Promise<OnChainMessageStatus> {
+    const { destBridge } = this.#getSourceAndDestBridge(messageDirection)
     return destBridge.getMessageStatus(message.messageHash)
   }
 

--- a/packages/hop-node/src/chains/Chains/polygon/PolygonMessageService.ts
+++ b/packages/hop-node/src/chains/Chains/polygon/PolygonMessageService.ts
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch'
+import wait from 'src/utils/wait'
 import { AbstractMessageService, IMessageService } from 'src/chains/Services/AbstractMessageService'
 import { BigNumber, providers, utils } from 'ethers'
 import { CanonicalMessengerRootConfirmationGasLimit } from 'src/constants'
@@ -6,7 +7,6 @@ import { FxPortalClient } from '@fxportal/maticjs-fxportal'
 import { Web3ClientPlugin } from '@maticnetwork/maticjs-ethers'
 import { defaultAbiCoder } from 'ethers/lib/utils'
 import { setProofApi, use } from '@maticnetwork/maticjs'
-import wait from 'src/utils/wait'
 
 type PolygonMessage = string
 type PolygonMessageStatus = string

--- a/packages/hop-node/src/chains/Chains/polygon/PolygonMessageService.ts
+++ b/packages/hop-node/src/chains/Chains/polygon/PolygonMessageService.ts
@@ -6,6 +6,7 @@ import { FxPortalClient } from '@fxportal/maticjs-fxportal'
 import { Web3ClientPlugin } from '@maticnetwork/maticjs-ethers'
 import { defaultAbiCoder } from 'ethers/lib/utils'
 import { setProofApi, use } from '@maticnetwork/maticjs'
+import wait from 'src/utils/wait'
 
 type PolygonMessage = string
 type PolygonMessageStatus = string
@@ -28,11 +29,6 @@ type PolygonApiResSuccess = {
 
 type PolygonApiRes = PolygonApiResError | PolygonApiResSuccess
 
-type MessageOpts = {
-  rootTunnelAddress: string
-  txBlockNumber: number
-}
-
 const polygonChainSlugs: Record<string, string> = {
   mainnet: 'matic',
   goerli: 'mumbai'
@@ -48,7 +44,7 @@ const polygonSdkVersion: Record<string, string> = {
   goerli: 'mumbai'
 }
 
-export class PolygonMessageService extends AbstractMessageService<PolygonMessage, PolygonMessageStatus, MessageOpts> implements IMessageService {
+export class PolygonMessageService extends AbstractMessageService<PolygonMessage, PolygonMessageStatus> implements IMessageService {
   ready: boolean = false
   apiUrl: string
   maticClient: any
@@ -75,25 +71,6 @@ export class PolygonMessageService extends AbstractMessageService<PolygonMessage
       })
   }
 
-  async relayL1ToL2Message (l1TxHash: string): Promise<providers.TransactionResponse> {
-    throw new Error('L1 to L2 message relay not supported. Messages are relayed with a system tx.')
-  }
-
-  async relayL2ToL1Message (l2TxHash: string): Promise<providers.TransactionResponse> {
-    // As of Jun 2023, the maticjs-fxportal client errors out with an underflow error
-    // To resolve the issue, this logic just rips out the payload generation and sends the tx manually
-    const rootTunnelAddress: string = await this.#getRootTunnelAddressFromTxHash(l2TxHash)
-    const tx = await this.l2Wallet.provider!.getTransactionReceipt(l2TxHash)
-
-    const messageOpts: MessageOpts = {
-      rootTunnelAddress,
-      txBlockNumber: tx.blockNumber
-    }
-
-    // Message is a txHash for Polygon
-    return this.validateMessageAndSendTransaction(l2TxHash, messageOpts)
-  }
-
   async #_initClient (l1Network: string): Promise<void> {
     const from = await this.l1Wallet.getAddress()
     const sdkNetwork = polygonSdkNetwork[l1Network]
@@ -115,6 +92,38 @@ export class PolygonMessageService extends AbstractMessageService<PolygonMessage
       }
     })
     this.ready = true
+  }
+
+  async #tilReady (): Promise<boolean> {
+    while (true) {
+      if (this.ready) {
+        return true
+      }
+      await wait(100)
+    }
+  }
+
+  async relayL1ToL2Message (l1TxHash: string): Promise<providers.TransactionResponse> {
+    throw new Error('L1 to L2 message relay not supported. Messages are relayed with a system tx.')
+  }
+
+  protected async sendRelayTx (message: PolygonMessage): Promise<providers.TransactionResponse> {
+    await this.#tilReady()
+    const rootTunnelAddress = await this.#getRootTunnelAddressFromTxHash(message)
+
+    // Generate payload
+    const logEventSig = '0x8c5261668696ce22758910d05bab8f186d6eb247ceac2af2e82c7dc17669b036'
+    const payload = await this.maticClient.exitUtil.buildPayloadForExit(message, logEventSig, true)
+
+    // Create tx data and send
+    const abi = ['function receiveMessage(bytes)']
+    const iface = new utils.Interface(abi)
+    const data = iface.encodeFunctionData('receiveMessage', [payload])
+    return this.l1Wallet.sendTransaction({
+      to: rootTunnelAddress,
+      data,
+      gasLimit: CanonicalMessengerRootConfirmationGasLimit
+    })
   }
 
   async #getRootTunnelAddressFromTxHash (l2TxHash: string): Promise<string> {
@@ -164,24 +173,6 @@ export class PolygonMessageService extends AbstractMessageService<PolygonMessage
     return defaultAbiCoder.decode(['address'], rootTunnelAddress)[0]
   }
 
-  protected async sendRelayTransaction (message: PolygonMessage, messageOpts: MessageOpts): Promise<providers.TransactionResponse> {
-    const { rootTunnelAddress } = messageOpts
-
-    // Generate payload
-    const logEventSig = '0x8c5261668696ce22758910d05bab8f186d6eb247ceac2af2e82c7dc17669b036'
-    const payload = await this.maticClient.exitUtil.buildPayloadForExit(message, logEventSig, true)
-
-    // Create tx data and send
-    const abi = ['function receiveMessage(bytes)']
-    const iface = new utils.Interface(abi)
-    const data = iface.encodeFunctionData('receiveMessage', [payload])
-    return this.l1Wallet.sendTransaction({
-      to: rootTunnelAddress,
-      data,
-      gasLimit: CanonicalMessengerRootConfirmationGasLimit
-    })
-  }
-
   protected async getMessage (txHash: string): Promise<PolygonMessage> {
     // Polygon message is defined by the txHash, so we return that
     return txHash
@@ -200,28 +191,28 @@ export class PolygonMessageService extends AbstractMessageService<PolygonMessage
     )
   }
 
-  protected async isMessageRelayable (messageStatus: PolygonMessageStatus, messageOpts: MessageOpts): Promise<boolean> {
-    const { txBlockNumber } = messageOpts
+  protected async isMessageRelayable (messageStatus: PolygonMessageStatus): Promise<boolean> {
+    const tx = await this.l2Wallet.provider!.getTransactionReceipt(messageStatus)
     const apiRes: PolygonApiResSuccess = (await this.#fetchBlockIncluded(messageStatus)) as PolygonApiResSuccess
 
     return (
       apiRes.message === 'success' &&
-      BigNumber.from(apiRes.start).lte(txBlockNumber) &&
-      BigNumber.from(apiRes.end).gte(txBlockNumber)
+      BigNumber.from(apiRes.start).lte(tx.blockNumber) &&
+      BigNumber.from(apiRes.end).gte(tx.blockNumber)
     )
   }
 
-  protected async isMessageRelayed (messageStatus: PolygonMessageStatus, messageOpts: MessageOpts): Promise<boolean> {
-    // This is not accurate, but we don't have a way to check if a message has been relayed
-    // This will suffice for how the bonder uses this call, but will not work more broadly
-    const { txBlockNumber } = messageOpts
+  protected async isMessageRelayed (messageStatus: PolygonMessageStatus): Promise<boolean> {
+    const tx = await this.l2Wallet.provider!.getTransactionReceipt(messageStatus)
     const apiRes: PolygonApiResSuccess = (await this.#fetchBlockIncluded(messageStatus)) as PolygonApiResSuccess
 
+    // This is not accurate, but we don't have a way to check if a message has been relayed
+    // This will suffice for how the bonder uses this call, but will not work more broadly
     return (
       apiRes.message === 'success' &&
       (
-        BigNumber.from(apiRes.start).gt(txBlockNumber) ||
-        BigNumber.from(apiRes.end).lt(txBlockNumber)
+        BigNumber.from(apiRes.start).gt(tx.blockNumber) ||
+        BigNumber.from(apiRes.end).lt(tx.blockNumber)
       )
     )
   }

--- a/packages/hop-node/src/chains/Chains/polygonzk/PolygonZkMessageService.ts
+++ b/packages/hop-node/src/chains/Chains/polygonzk/PolygonZkMessageService.ts
@@ -25,14 +25,10 @@ const polygonSdkVersion: Record<string, string> = {
   goerli: 'blueberry'
 }
 
-type MessageOpts = {
-  messageDirection: MessageDirection
-}
-
 type Message = string
 type MessageStatus = string
 
-export class PolygonZkMessageService extends AbstractMessageService<Message, MessageStatus, MessageOpts> implements IMessageService {
+export class PolygonZkMessageService extends AbstractMessageService<Message, MessageStatus> implements IMessageService {
   ready: boolean = false
   apiUrl: string
   zkEvmClient: ZkEvmClient
@@ -82,33 +78,15 @@ export class PolygonZkMessageService extends AbstractMessageService<Message, Mes
   }
 
   async #tilReady (): Promise<boolean> {
-    if (this.ready) {
-      return true
+    while (true) {
+      if (this.ready) {
+        return true
+      }
+      await wait(100)
     }
-    await wait(100)
-    return await this.#tilReady()
   }
-
-  async relayL1ToL2Message (l1TxHash: string): Promise<providers.TransactionResponse> {
+  protected async sendRelayTx (message: Message, messageDirection: MessageDirection): Promise<providers.TransactionResponse> {
     await this.#tilReady()
-    const messageOpts: MessageOpts = {
-      messageDirection: MessageDirection.L1_TO_L2
-    }
-
-    return this.validateMessageAndSendTransaction(l1TxHash, messageOpts)
-  }
-
-  async relayL2ToL1Message (l2TxHash: string): Promise<providers.TransactionResponse> {
-    await this.#tilReady()
-    const messageOpts: MessageOpts = {
-      messageDirection: MessageDirection.L2_TO_L1
-    }
-
-    return this.validateMessageAndSendTransaction(l2TxHash, messageOpts)
-  }
-
-  protected async sendRelayTransaction (message: Message, messageOpts: MessageOpts): Promise<providers.TransactionResponse> {
-    const { messageDirection } = messageOpts
 
     // The bridge to claim on will be on the opposite chain that the source tx is on
     const { sourceBridge, destBridge } = this.#getSourceAndDestBridge(messageDirection)
@@ -151,10 +129,10 @@ export class PolygonZkMessageService extends AbstractMessageService<Message, Mes
     return message
   }
 
-  protected async isMessageInFlight (messageStatus: MessageStatus, messageOpts: MessageOpts): Promise<boolean> {
+  protected async isMessageInFlight (messageStatus: MessageStatus, messageDirection: MessageDirection): Promise<boolean> {
     // A message is in flight if the client does not know about it
     try {
-      if (messageOpts.messageDirection === MessageDirection.L1_TO_L2) {
+      if (messageDirection === MessageDirection.L1_TO_L2) {
         await this.zkEvmClient.isDepositClaimable(messageStatus)
       } else {
         await this.zkEvmClient.isWithdrawExitable(messageStatus)
@@ -165,17 +143,17 @@ export class PolygonZkMessageService extends AbstractMessageService<Message, Mes
     return false
   }
 
-  protected async isMessageRelayable (messageStatus: MessageStatus, messageOpts: MessageOpts): Promise<boolean> {
-    if (messageOpts.messageDirection === MessageDirection.L1_TO_L2) {
+  protected async isMessageRelayable (messageStatus: MessageStatus, messageDirection: MessageDirection): Promise<boolean> {
+    if (messageDirection === MessageDirection.L1_TO_L2) {
       return this.zkEvmClient.isDepositClaimable(messageStatus)
     } else {
       return this.zkEvmClient.isWithdrawExitable(messageStatus)
     }
   }
 
-  protected async isMessageRelayed (messageStatus: MessageStatus, messageOpts: MessageOpts): Promise<boolean> {
+  protected async isMessageRelayed (messageStatus: MessageStatus, messageDirection: MessageDirection): Promise<boolean> {
     // The SDK return type is says string but it returns a bool so we have to convert it to unknown first
-    if (messageOpts.messageDirection === MessageDirection.L1_TO_L2) {
+    if (messageDirection === MessageDirection.L1_TO_L2) {
       return ((await this.zkEvmClient.isDeposited(messageStatus)) as unknown) as boolean
     } else {
       return ((await this.zkEvmClient.isExited(messageStatus)) as unknown) as boolean

--- a/packages/hop-node/src/chains/Chains/polygonzk/PolygonZkMessageService.ts
+++ b/packages/hop-node/src/chains/Chains/polygonzk/PolygonZkMessageService.ts
@@ -85,6 +85,7 @@ export class PolygonZkMessageService extends AbstractMessageService<Message, Mes
       await wait(100)
     }
   }
+
   protected async sendRelayTx (message: Message, messageDirection: MessageDirection): Promise<providers.TransactionResponse> {
     await this.#tilReady()
 

--- a/packages/hop-node/src/chains/Chains/scroll/ScrollMessageService.ts
+++ b/packages/hop-node/src/chains/Chains/scroll/ScrollMessageService.ts
@@ -5,11 +5,7 @@ type Message = string
 type MessageStatus = string
 
 export class ScrollMessageService extends AbstractMessageService<Message, MessageStatus> implements IMessageService {
-  async relayL2ToL1Message (l2TxHash: string): Promise<providers.TransactionResponse> {
-    throw new Error('implement')
-  }
-
-  protected async sendRelayTransaction (message: Message): Promise<providers.TransactionResponse> {
+  protected async sendRelayTx (message: Message): Promise<providers.TransactionResponse> {
     throw new Error('implement')
   }
 

--- a/packages/hop-node/src/chains/Chains/zksync/ZkSyncMessageService.ts
+++ b/packages/hop-node/src/chains/Chains/zksync/ZkSyncMessageService.ts
@@ -5,11 +5,7 @@ type Message = string
 type MessageStatus = string
 
 export class ZkSyncMessageService extends AbstractMessageService<Message, MessageStatus> implements IMessageService {
-  async relayL2ToL1Message (l2THash: string): Promise<providers.TransactionResponse> {
-    throw new Error('implement')
-  }
-
-  protected async sendRelayTransaction (message: Message): Promise<providers.TransactionResponse> {
+  protected async sendRelayTx (message: Message): Promise<providers.TransactionResponse> {
     throw new Error('implement')
   }
 

--- a/packages/hop-node/src/chains/Services/AbstractMessageService.ts
+++ b/packages/hop-node/src/chains/Services/AbstractMessageService.ts
@@ -32,7 +32,7 @@ export abstract class AbstractMessageService<Message, MessageStatus> extends Abs
   protected readonly l2Wallet: Signer
 
   protected abstract sendRelayTx (message: Message, messageDirection?: MessageDirection): Promise<providers.TransactionResponse>
-  
+
   protected abstract getMessage (txHash: string, messageDirection?: MessageDirection, messageIndex?: number): Promise<Message>
   protected abstract getMessageStatus (message: Message, messageDirection: MessageDirection): Promise<MessageStatus>
 

--- a/packages/hop-node/src/chains/Services/AbstractMessageService.ts
+++ b/packages/hop-node/src/chains/Services/AbstractMessageService.ts
@@ -18,16 +18,18 @@ export interface IMessageService {
   relayL2ToL1Message(l2TxHash: string, messageIndex?: number): Promise<providers.TransactionResponse>
 }
 
-export abstract class AbstractMessageService<Message, MessageStatus, MessageOpts = null> extends AbstractService {
+export abstract class AbstractMessageService<Message, MessageStatus> extends AbstractService implements IMessageService {
   protected readonly l1Wallet: Signer
   protected readonly l2Wallet: Signer
 
-  protected abstract getMessage (txHash: string, opts: MessageOpts | null): Promise<Message>
-  protected abstract getMessageStatus (message: Message, opts: MessageOpts | null): Promise<MessageStatus>
-  protected abstract sendRelayTransaction (message: Message, messageOpts: MessageOpts | null): Promise<providers.TransactionResponse>
-  protected abstract isMessageInFlight (messageStatus: MessageStatus, messageOpts: MessageOpts | null): Promise<boolean> | boolean
-  protected abstract isMessageRelayable (messageStatus: MessageStatus, messageOpts: MessageOpts | null): Promise<boolean> | boolean
-  protected abstract isMessageRelayed (messageStatus: MessageStatus, messageOpts: MessageOpts | null): Promise<boolean> | boolean
+  protected abstract sendRelayTx (message: Message, messageDirection?: MessageDirection): Promise<providers.TransactionResponse>
+  
+  protected abstract getMessage (txHash: string, messageDirection?: MessageDirection, messageIndex?: number): Promise<Message>
+  protected abstract getMessageStatus (message: Message, messageDirection: MessageDirection): Promise<MessageStatus>
+
+  protected abstract isMessageInFlight (messageStatus: MessageStatus, messageDirection?: MessageDirection): Promise<boolean> | boolean
+  protected abstract isMessageRelayable (messageStatus: MessageStatus, messageDirection?: MessageDirection): Promise<boolean> | boolean
+  protected abstract isMessageRelayed (messageStatus: MessageStatus, messageDirection?: MessageDirection): Promise<boolean> | boolean
 
   constructor (chainSlug: string) {
     super(chainSlug)
@@ -36,40 +38,42 @@ export abstract class AbstractMessageService<Message, MessageStatus, MessageOpts
     this.l2Wallet = wallets.get(this.chainSlug)
   }
 
-  /**
-   * To be overridden by subclasses that support manual L1 to L2 message relaying
-   */
-  async relayL1ToL2Message (l1TxHash: string): Promise<providers.TransactionResponse> {
-    throw new Error('L1 to L2 message relay not supported. Messages may be relayed with a system tx.')
+  async relayL1ToL2Message (l1TxHash: string, messageIndex?: number): Promise<providers.TransactionResponse> {
+    const messageDirection: MessageDirection = MessageDirection.L1_TO_L2
+    return await this.#relayMessage(l1TxHash, messageDirection, messageIndex)
   }
 
-  // Call a private method so the validation is guaranteed to run in order
-  protected async validateMessageAndSendTransaction (txHash: string, messageOpts: MessageOpts | null = null): Promise<providers.TransactionResponse> {
-    return this.#validateMessageAndSendTransaction(txHash, messageOpts)
+  async relayL2ToL1Message (l2TxHash: string, messageIndex?: number): Promise<providers.TransactionResponse> {
+    const messageDirection: MessageDirection = MessageDirection.L2_TO_L1
+    return await this.#relayMessage(l2TxHash, messageDirection, messageIndex)
   }
 
-  async #validateMessageAndSendTransaction (txHash: string, messageOpts: MessageOpts | null): Promise<providers.TransactionResponse> {
-    const message: Message = await this.getMessage(txHash, messageOpts)
-    const messageStatus: MessageStatus = await this.getMessageStatus(message, messageOpts)
-    await this.#validateMessageStatus(messageStatus, messageOpts)
-    return this.sendRelayTransaction(message, messageOpts)
+  async #relayMessage (txHash: string, messageDirection: MessageDirection, messageIndex?: number): Promise<providers.TransactionResponse> {
+    const message: Message = await this.getMessage(txHash, messageDirection, messageIndex)
+    await this.#validateMessage(message, messageDirection)
+    return await this.sendRelayTx(message, messageDirection)
   }
 
-  async #validateMessageStatus (messageStatus: MessageStatus, messageOpts: MessageOpts | null): Promise<void> {
+  async #validateMessage (message: Message, messageDirection: MessageDirection): Promise<void> {
+    const messageStatus: MessageStatus = await this.getMessageStatus(message, messageDirection)
+    await this.#validateMessageStatus(messageStatus, messageDirection)
+  }
+
+  async #validateMessageStatus (messageStatus: MessageStatus, messageDirection: MessageDirection): Promise<void> {
     if (!messageStatus) {
       throw new MessageUnknownError('validateMessageStatus: Unknown message status')
     }
 
-    if (await this.isMessageInFlight(messageStatus, messageOpts)) {
+    if (await this.isMessageInFlight(messageStatus, messageDirection)) {
       throw new MessageInFlightError('validateMessageStatus: Message has not yet been checkpointed')
     }
 
-    if (await this.isMessageRelayed(messageStatus, messageOpts)) {
+    if (await this.isMessageRelayed(messageStatus, messageDirection)) {
       throw new MessageRelayedError('validateMessageStatus: Message has already been relayed')
     }
 
     // If the message is here but is not relayable, it is in an invalid state
-    if (!(await this.isMessageRelayable(messageStatus, messageOpts))) {
+    if (!(await this.isMessageRelayable(messageStatus, messageDirection))) {
       throw new MessageInvalidError('validateMessageStatus: Invalid message state')
     }
   }

--- a/packages/hop-node/src/chains/Services/AbstractMessageService.ts
+++ b/packages/hop-node/src/chains/Services/AbstractMessageService.ts
@@ -18,6 +18,15 @@ export interface IMessageService {
   relayL2ToL1Message(l2TxHash: string, messageIndex?: number): Promise<providers.TransactionResponse>
 }
 
+/**
+ * @todo Future features:
+ * - messageDirection and messageIndex should in a single object, along with child class specific options, such
+ *   as messageBlockNumber or API response. They should all be optional. The former two items resolve the case
+ *   where a getMessage call by a child class needs the messageIndex but not the direction. The latter allows
+ *   for cacheing of data that is used in multiple methods, such as the block number of a message so that it
+ *   does not need to be derived via an RPC call for each status check method.
+ */
+
 export abstract class AbstractMessageService<Message, MessageStatus> extends AbstractService implements IMessageService {
   protected readonly l1Wallet: Signer
   protected readonly l2Wallet: Signer
@@ -38,6 +47,12 @@ export abstract class AbstractMessageService<Message, MessageStatus> extends Abs
     this.l2Wallet = wallets.get(this.chainSlug)
   }
 
+  /**
+   *  Public Interface Methods
+   *  @dev Do not override these methods in subclasses unless you know what you are doing
+   *  @dev If a subclass does not implement relays for a certain direction, override this method and throw
+   */
+
   async relayL1ToL2Message (l1TxHash: string, messageIndex?: number): Promise<providers.TransactionResponse> {
     const messageDirection: MessageDirection = MessageDirection.L1_TO_L2
     return await this.#relayMessage(l1TxHash, messageDirection, messageIndex)
@@ -47,6 +62,10 @@ export abstract class AbstractMessageService<Message, MessageStatus> extends Abs
     const messageDirection: MessageDirection = MessageDirection.L2_TO_L1
     return await this.#relayMessage(l2TxHash, messageDirection, messageIndex)
   }
+
+  /**
+   * Internal Methods
+   */
 
   async #relayMessage (txHash: string, messageDirection: MessageDirection, messageIndex?: number): Promise<providers.TransactionResponse> {
     const message: Message = await this.getMessage(txHash, messageDirection, messageIndex)


### PR DESCRIPTION
@miguelmota one more purely architectural change for easier addition of chains.

* Correctly implements template design pattern. Now avoids child message service (i.e. ArbitrumMessageService.ts) from having to know that it has to call the abstract class `validateMessageAndSendTransaction()` in order to send a tx. Abstract class now handles everything with the child class just needing to tell it how to send a tx.
* More explicit params throughout (but open to using an `opts` object later when more chains introduce more needs)