### PR TITLE
hop-node: GasBoost: Add timeout for tx wait

### DIFF
--- a/packages/hop-node/src/gasboost/GasBoostTransaction.ts
+++ b/packages/hop-node/src/gasboost/GasBoostTransaction.ts
@@ -666,7 +666,9 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
   }
 
   private async getReceipt (txHash: string) {
-    return this.signer.provider!.waitForTransaction(txHash)
+    const confirms = 1
+    const timeoutMs = 10 * 60 * 1000
+    return this.signer.provider!.waitForTransaction(txHash, confirms, timeoutMs)
   }
 
   private async startPoller () {
@@ -923,7 +925,7 @@ class GasBoostTransaction extends EventEmitter implements providers.TransactionR
       sentAt: Date.now()
     })
     this.logger.debug(`tracking: inflightItems${JSON.stringify(this.inflightItems)}`)
-    this.signer.provider!.waitForTransaction(tx.hash).then((receipt: providers.TransactionReceipt) => {
+    this.getReceipt(tx.hash).then((receipt: providers.TransactionReceipt) => {
       this.logger.debug(`tracking: wait completed. tx hash ${tx.hash}`)
       this.handleConfirmation(tx.hash, receipt)
     })


### PR DESCRIPTION
Ethers allows an optional timeout to be used for `.wait()`, and [`.waitForTransaction()`](https://github.com/ethers-io/ethers.js/blob/ad5f1c5fc7b73cfb20d9012b669e9dcb9122d244/src.ts/providers/provider.ts#L2058).

This adds a timeout of 10 minutes, to ensure that there's no indefinite polling of a tx hash that doesn't exist. 