### PR TITLE
upgrade checkout action to version using node20

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -14,7 +14,7 @@ jobs:
         working-directory: .
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up node
         uses: actions/setup-node@v2

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -65,7 +65,7 @@ jobs:
       changelog: ${{ steps.github_tag_action.outputs.changelog }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Bump version and push tag
         id: github_tag_action
@@ -93,7 +93,7 @@ jobs:
         working-directory: .
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Log set env vars
         run: |


### PR DESCRIPTION
Node16 is deprecated and Actions using it will stop working 3rd of June
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

See warnings here
https://github.com/hop-protocol/hop/actions/runs/9075821996