### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | Lib/App | Current Version | Description |
 | --- | --- |  --- |
 [@hop-protocol/v2-sdk](packages/v2-sdk) | [![npm version](https://badge.fury.io/js/%40hop-protocol%2Fv2-sdk.svg)](https://badge.fury.io/js/) | V2 TypeScript Hop SDK |
-[@hop-protocol/v2-hop-node](packages/v-2hop-node) | [![npm version](https://badge.fury.io/js/%40hop-protocol%2Fv2-hop-node.svg)](https://badge.fury.io/js/) | TypeScript Hop Node |
+[@hop-protocol/v2-hop-node](packages/v2-hop-node) | [![npm version](https://badge.fury.io/js/%40hop-protocol%2Fv2-hop-node.svg)](https://badge.fury.io/js/) | TypeScript Hop Node |
 
 ## Quickstart
 

--- a/packages/sdk/docs/classes/Hop.md
+++ b/packages/sdk/docs/classes/Hop.md
@@ -1,6 +1,6 @@
 # Class: Hop
 
-Class reprensenting Hop
+Class representing Hop
  Hop
 
 ## Hierarchy

--- a/packages/sdk/docs/classes/Token.md
+++ b/packages/sdk/docs/classes/Token.md
@@ -1,6 +1,6 @@
 # Class: Token
 
-Class reprensenting ERC20 Token
+Class representing ERC20 Token
  Token
 
 ## Hierarchy


### PR DESCRIPTION

## Changes Made

### packages/sdk/docs/classes/Hop.md
- Changed "reprensenting" to "representing"
Old: `Class reprensenting Hop`
New: `Class representing Hop`

### packages/sdk/docs/classes/Token.md  
- Changed "reprensenting" to "representing"
Old: `Class reprensenting ERC20 Token`
New: `Class representing ERC20 Token`

### README.md
- Fixed package path typo
Old: `[@hop-protocol/v2-hop-node](packages/v-2hop-node)`
New: `[@hop-protocol/v2-hop-node](packages/v2-hop-node)`

## Why these changes are needed

1. Correct spelling improves documentation quality and professionalism
2. Consistent terminology helps developers better understand the codebase
3. Fixed package path ensures correct linking in documentation
4. These changes make the documentation more maintainable and easier to read

The corrections focus on fixing typos while maintaining the original meaning and structure of the documentation. No functional changes were made to the code.