### PR TITLE
fix: submit on-chain challenge transaction in ChallengeWatcher

### DIFF
--- a/packages/hop-node/src/watchers/ChallengeWatcher.ts
+++ b/packages/hop-node/src/watchers/ChallengeWatcher.ts
@@ -109,6 +109,12 @@ class ChallengeWatcher extends BaseWatcher {
     const challengeMsg = `TransferRoot should be challenged! Root id: ${transferRootId}. Root hash: ${transferRootHash} Total amt: ${totalAmount}.`
     logger.debug(challengeMsg)
     await this.notifier.warn(challengeMsg)
+
+    const challengeTx = await l1Bridge.challengeTransferRootBond(transferRootHash, totalAmount, destinationChainId)
+    if (challengeTx) {
+      logger.info(`Challenge transaction sent: ${challengeTx.hash}`)
+    }
+
     await this.db.transferRoots.update(transferRootId, {
       challenged: true
     })


### PR DESCRIPTION
ChallengeWatcher.checkChallengeableTransferRoot() detects fraudulent transfer root bonds but only logs a warning and sends a notification without ever calling L1Bridge.challengeTransferRootBond() to submit the actual on-chain challenge transaction.

The challengeTransferRootBond() method is fully implemented in L1Bridge (line 200-213) and correctly calls the L1 bridge contract's challengeTransferBond() function, but it is never invoked from anywhere in the watcher logic.

If the on-call operator misses or is slow to respond to the notification, a fraudulent transfer root can pass the challenge window unchallenged, allowing the malicious bonder to settle withdrawals against the fraudulent root and drain bridge funds.

This patch adds the missing on-chain challenge call using the variables already available in scope (transferRootHash, totalAmount, destinationChainId from line 81).