### PR TITLE
fix(api): block private rpcUrl overrides on /v1/quote (SSRF)

### DIFF
--- a/packages/api/src/rpcUrlSafety.ts
+++ b/packages/api/src/rpcUrlSafety.ts
@@ -1,0 +1,93 @@
+import { lookup } from 'dns/promises'
+import net from 'net'
+
+/**
+ * Reject rpcUrl overrides that would make the API server fetch private /
+ * link-local / metadata addresses (SSRF). Quote handlers install these URLs
+ * as ethers providers and call them during getSendData.
+ */
+
+function ipv4ToInt (ip: string): number {
+  return ip.split('.').reduce((acc, octet) => (acc << 8) + Number(octet), 0) >>> 0
+}
+
+export function isBlockedIp (ip: string): boolean {
+  if (net.isIPv4(ip)) {
+    const n = ipv4ToInt(ip)
+    const inRange = (base: string, prefix: number) => {
+      const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0
+      return (n & mask) === (ipv4ToInt(base) & mask)
+    }
+    return (
+      inRange('0.0.0.0', 8) || // "this" network
+      inRange('10.0.0.0', 8) ||
+      inRange('127.0.0.0', 8) ||
+      inRange('169.254.0.0', 16) || // link-local / cloud metadata
+      inRange('172.16.0.0', 12) ||
+      inRange('192.168.0.0', 16) ||
+      inRange('100.64.0.0', 10) // CGNAT
+    )
+  }
+
+  if (net.isIPv6(ip)) {
+    const normalized = ip.toLowerCase()
+    if (normalized === '::1' || normalized === '::') return true
+    // Unique local fc00::/7 and link-local fe80::/10
+    if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true
+    if (normalized.startsWith('fe8') || normalized.startsWith('fe9') ||
+        normalized.startsWith('fea') || normalized.startsWith('feb')) {
+      return true
+    }
+    // IPv4-mapped
+    if (normalized.startsWith(':ffff:')) {
+      const v4 = normalized.slice(':ffff:'.length)
+      if (net.isIPv4(v4)) return isBlockedIp(v4)
+    }
+  }
+
+  return false
+}
+
+export async function assertSafeRpcUrl (raw: string): Promise<string> {
+  let parsed: URL
+  try {
+    parsed = new URL(raw)
+  } catch {
+    throw new Error(`rpcUrl has an invalid url "${raw}"`)
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`rpcUrl protocol must be http(s), got "${parsed.protocol}"`)
+  }
+
+  const host = parsed.hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  if (!host) {
+    throw new Error('rpcUrl hostname is required')
+  }
+  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local')) {
+    throw new Error(`rpcUrl host "${host}" is not allowed`)
+  }
+
+  if (net.isIP(host)) {
+    if (isBlockedIp(host)) {
+      throw new Error(`rpcUrl host "${host}" is not allowed`)
+    }
+  } else {
+    let addresses: Array<{ address: string, family: number }>
+    try {
+      addresses = await lookup(host, { all: true, verbatim: true })
+    } catch {
+      throw new Error(`rpcUrl host "${host}" could not be resolved`)
+    }
+    if (!addresses.length) {
+      throw new Error(`rpcUrl host "${host}" could not be resolved`)
+    }
+    for (const { address } of addresses) {
+      if (isBlockedIp(address)) {
+        throw new Error(`rpcUrl host "${host}" resolves to blocked address "${address}"`)
+      }
+    }
+  }
+
+  return parsed.toString()
+}

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -4,6 +4,7 @@ import { Hop } from '@hop-protocol/sdk'
 import { gitRev, port, trustProxy } from './config.js'
 import { ipRateLimitMiddleware } from './rateLimit.js'
 import { responseCache } from './responseCache.js'
+import { assertSafeRpcUrl } from './rpcUrlSafety.js'
 
 const app = express()
 
@@ -60,14 +61,16 @@ app.get('/v1/quote', responseCache, ipRateLimitMiddleware, async (req, res) => {
         }
         const url = (rpcUrl as any)[chain]
         try {
-          customRpcProviderUrls[chain] = new URL(url).toString()
-        } catch (err) {
-          throw new Error(`"rpcUrl[${chain}]" has an invalid url "${url}"`)
+          // Block private/link-local/metadata targets: these URLs are installed as
+          // ethers providers and fetched during getSendData (SSRF).
+          customRpcProviderUrls[chain] = await assertSafeRpcUrl(url)
+        } catch (err: any) {
+          throw new Error(`"rpcUrl[${chain}]" ${err?.message || 'is not allowed'}`)
         }
       }
     }
 
-    if (Object.keys(customRpcProviderUrls)) {
+    if (Object.keys(customRpcProviderUrls).length) {
       instance.setChainProviderUrls(customRpcProviderUrls)
     }
 

--- a/packages/api/test/rpcUrlSafety.test.ts
+++ b/packages/api/test/rpcUrlSafety.test.ts
@@ -1,0 +1,24 @@
+import { assertSafeRpcUrl, isBlockedIp } from '../src/rpcUrlSafety'
+
+describe('rpcUrlSafety', () => {
+  it('blocks loopback, private, link-local, and CGNAT IPv4', () => {
+    expect(isBlockedIp('127.0.0.1')).toBe(true)
+    expect(isBlockedIp('10.0.0.1')).toBe(true)
+    expect(isBlockedIp('192.168.1.1')).toBe(true)
+    expect(isBlockedIp('172.16.0.1')).toBe(true)
+    expect(isBlockedIp('169.254.169.254')).toBe(true)
+    expect(isBlockedIp('100.64.0.1')).toBe(true)
+    expect(isBlockedIp('1.1.1.1')).toBe(false)
+  })
+
+  it('blocks localhost and private literal URLs', async () => {
+    await expect(assertSafeRpcUrl('http://127.0.0.1:8545')).rejects.toThrow(/not allowed/)
+    await expect(assertSafeRpcUrl('http://169.254.169.254/latest/meta-data')).rejects.toThrow(/not allowed/)
+    await expect(assertSafeRpcUrl('http://localhost:8545')).rejects.toThrow(/not allowed/)
+    await expect(assertSafeRpcUrl('file:///etc/passwd')).rejects.toThrow(/protocol/)
+  })
+
+  it('allows public https RPC URLs by IP literal', async () => {
+    await expect(assertSafeRpcUrl('https://1.1.1.1/rpc')).resolves.toBe('https://1.1.1.1/rpc')
+  })
+})


### PR DESCRIPTION
## Summary
`GET /v1/quote` accepts `rpcUrl[<chain>]=…` query params, validated only with `new URL(...)`, then calls `Hop.setChainProviderUrls` and `bridge.getSendData`. That installs attacker-controlled RPC endpoints as ethers providers and fetches them server-side (gas price / send-data path), enabling SSRF to loopback, RFC1918, link-local / cloud metadata (`169.254.169.254`), and CGNAT.

Example (conceptual):  
`/v1/quote?...&rpcUrl[arbitrum]=http://169.254.169.254/`

This PR adds `assertSafeRpcUrl` before install: http(s) only, block localhost hostnames, resolve DNS and reject blocked addresses.

Also fixes `if (Object.keys(customRpcProviderUrls))` (always truthy) to check `.length` before `setChainProviderUrls`.

## Test plan
- [x] `NODE_OPTIONS='--experimental-vm-modules' jest --config packages/api/jest.config.mjs packages/api/test/rpcUrlSafety.test.ts` → 3/3
- [ ] Manual: public RPC URL still quotes; `rpcUrl[optimism]=http://127.0.0.1` returns error JSON


Made with [Cursor](https://cursor.com)